### PR TITLE
Rate mirrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ A massive thank you to the broader open-source community. This toolkit was inspi
 
 ### Arch Linux Optimization
 
-- [Optimizing Mirror List with Reflector](https://ostechnix.com/retrieve-latest-mirror-list-using-reflector-arch-linux/)
+- [Optimizing Mirror List with `rate-mirrors`](https://github.com/westandskif/rate-mirrors)
+- [Create `systemd` service as a non `root` user](https://sekor.eu.org/techlog/systemd-without-root-instances/)
 - [Implementing ZRAM-Swap](https://www.dwarmstrong.org/zram-swap/)
 - [Arch Linux Official Documentation](https://wiki.archlinux.org/)
 

--- a/scripts/configurations/essentials/mirrors/rate-mirrors.conf
+++ b/scripts/configurations/essentials/mirrors/rate-mirrors.conf
@@ -1,0 +1,1 @@
+rate-mirrors arch | sudo tee /etc/pacman.d/mirrorlist

--- a/scripts/configurations/essentials/mirrors/reflector.conf
+++ b/scripts/configurations/essentials/mirrors/reflector.conf
@@ -1,8 +1,0 @@
-# Path to save mirror list.
---save /etc/pacman.d/mirrorlist
-# Protocol to use when choosing mirrors.
---protocol https
-# Number of mirrors to fetch.
---latest 10
-# Sort mirrors by download rate.
---sort rate

--- a/scripts/utilities/essentials.sh
+++ b/scripts/utilities/essentials.sh
@@ -15,9 +15,6 @@ source "$ESSENTIALS_SCRIPT_DIRECTORY/../helpers/functions/packages.sh"
 # ? Importing constants.sh is not needed, because it is already sourced in the logs script.
 # ? Importing logs.sh is not needed, because it is already sourced in the other function scripts.
 
-# Install and configure mirror list manager.
-sh $ESSENTIALS_SCRIPT_DIRECTORY/../helpers/essentials/mirrors.sh
-
 # Essential packages.
 ESSENTIAL_PACKAGES="base-devel git networkmanager"
 
@@ -33,6 +30,9 @@ sh $ESSENTIALS_SCRIPT_DIRECTORY/../helpers/essentials/pacman.sh
 
 # Install and configure AUR helper.
 sh $ESSENTIALS_SCRIPT_DIRECTORY/../helpers/essentials/aur.sh
+
+# Install and configure mirror list manager.
+sh $ESSENTIALS_SCRIPT_DIRECTORY/../helpers/essentials/mirrors.sh
 
 # Install and configure system information tool.
 sh $ESSENTIALS_SCRIPT_DIRECTORY/../helpers/essentials/information.sh


### PR DESCRIPTION
# Description

This PR replaces `reflector` with the `rate-mirrors` package. Additionally, it sets up a `systemd` user service to automatically refresh the mirrors list at startup.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Performed manual tests on a fresh Arch Linux installation.