### PR TITLE
refactor: move runtime flags to /var/lib/arch-tuner/state.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -29,6 +29,10 @@ source "$INSTALL_SCRIPT_DIRECTORY/scripts/helpers/functions/system.sh"
 # shellcheck disable=SC1090 # Intended pattern for sourcing core configuration files.
 source "$INSTALL_SCRIPT_DIRECTORY/scripts/helpers/functions/strings.sh"
 # shellcheck disable=SC1090 # Intended pattern for sourcing core configuration files.
+source "$INSTALL_SCRIPT_DIRECTORY/scripts/helpers/functions/state.sh"
+# shellcheck disable=SC1090 # Intended pattern for sourcing core configuration files.
+source_state
+# shellcheck disable=SC1090 # Intended pattern for sourcing core configuration files.
 source "$FLAGS_SCRIPT_PATH"
 # shellcheck disable=SC1090 # Intended pattern for sourcing core configuration files.
 source "$CONSTANTS_SCRIPT_PATH"
@@ -84,10 +88,10 @@ for script in "${ORDERED_SCRIPTS[@]}"; do
             if [[ "$script" == "essentials" || "$script" == "privacy" ]]; then
 
                 # Before rebooting, if the script is the first one the "essentials" one, change the INITIAL_SETUP flag to 1 (false).
-                [[ "$script" == "essentials" ]] && change_flag_value "INITIAL_SETUP" 1 "$FLAGS_SCRIPT_PATH"
+                [[ "$script" == "essentials" ]] && change_flag_value "INITIAL_SETUP" 1
 
                 # Change the completion flag value to 0 (true).
-                change_flag_value "$completion_flag" 0 "$FLAGS_SCRIPT_PATH"
+                change_flag_value "$completion_flag" 0
             elif [ "$script" == "security" ]; then
                 log_success "Installation procedure finished!"
                 log_success "Your system is ready to use!"

--- a/install.sh
+++ b/install.sh
@@ -27,10 +27,6 @@ source "$INSTALL_SCRIPT_DIRECTORY/scripts/helpers/functions/ui.sh"
 # shellcheck disable=SC1090 # Intended pattern for sourcing core configuration files.
 source "$INSTALL_SCRIPT_DIRECTORY/scripts/helpers/functions/system.sh"
 # shellcheck disable=SC1090 # Intended pattern for sourcing core configuration files.
-source "$INSTALL_SCRIPT_DIRECTORY/scripts/helpers/functions/strings.sh"
-# shellcheck disable=SC1090 # Intended pattern for sourcing core configuration files.
-source "$INSTALL_SCRIPT_DIRECTORY/scripts/helpers/functions/state.sh"
-# shellcheck disable=SC1090 # Intended pattern for sourcing core configuration files.
 source_state
 # shellcheck disable=SC1090 # Intended pattern for sourcing core configuration files.
 source "$FLAGS_SCRIPT_PATH"

--- a/install.sh
+++ b/install.sh
@@ -9,8 +9,7 @@ set -e
 # Constant variable of the scripts' working directory to use for relative paths.
 INSTALL_SCRIPT_DIRECTORY=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
-# Constant variable for the flags script path.
-FLAGS_SCRIPT_PATH="$INSTALL_SCRIPT_DIRECTORY/scripts/core/flags.sh"
+# Constant variable for the constants script path.
 CONSTANTS_SCRIPT_PATH="$INSTALL_SCRIPT_DIRECTORY/scripts/core/constants.sh"
 
 declare -a ORDERED_SCRIPTS=("essentials" "privacy" "security")
@@ -27,11 +26,9 @@ source "$INSTALL_SCRIPT_DIRECTORY/scripts/helpers/functions/ui.sh"
 # shellcheck disable=SC1090 # Intended pattern for sourcing core configuration files.
 source "$INSTALL_SCRIPT_DIRECTORY/scripts/helpers/functions/system.sh"
 # shellcheck disable=SC1090 # Intended pattern for sourcing core configuration files.
-source_state
-# shellcheck disable=SC1090 # Intended pattern for sourcing core configuration files.
-source "$FLAGS_SCRIPT_PATH"
-# shellcheck disable=SC1090 # Intended pattern for sourcing core configuration files.
 source "$CONSTANTS_SCRIPT_PATH"
+# shellcheck disable=SC1090 # Intended pattern for sourcing core configuration files.
+source_state
 
 # Ask user for backup confirmation before proceeding.
 if [[ "$INITIAL_SETUP" -eq 0 ]]; then

--- a/scripts/helpers/essentials/aur.sh
+++ b/scripts/helpers/essentials/aur.sh
@@ -14,25 +14,25 @@ source "$AUR_SCRIPT_DIRECTORY/../functions/packages.sh"
 source "$AUR_SCRIPT_DIRECTORY/../functions/ui.sh"
 
 # Check if an AUR helper is already installed.
-aur_helper=""
-if command -v paru &>/dev/null; then
+    aur_helper=""
+    if command -v paru &>/dev/null; then
 
-    # Change the 'constant' value to "paru".
-    aur_helper="paru"
-    change_flag_value "AUR_PACKAGE_MANAGER" "paru" "$AUR_SCRIPT_DIRECTORY/../../core/constants.sh"
-elif command -v yay &>/dev/null; then
+        # Change the 'constant' value to "paru".
+        aur_helper="paru"
+        change_flag_value "AUR_PACKAGE_MANAGER" "paru"
+    elif command -v yay &>/dev/null; then
 
-    # Change the 'constant' value to "paru".
-    aur_helper="yay"
-    change_flag_value "AUR_PACKAGE_MANAGER" "yay" "$AUR_SCRIPT_DIRECTORY/../../core/constants.sh"
-else
+        # Change the 'constant' value to "paru".
+        aur_helper="yay"
+        change_flag_value "AUR_PACKAGE_MANAGER" "yay"
+    else
 
-    # Get the user's choice about AUR helper.
-    declare -a AUR_OPTIONS=("paru" "yay")
-    aur_helper=$(choose_option "Choose an AUR helper" "${AUR_OPTIONS[@]}")
+        # Get the user's choice about AUR helper.
+        declare -a AUR_OPTIONS=("paru" "yay")
+        aur_helper=$(choose_option "Choose an AUR helper" "${AUR_OPTIONS[@]}")
 
-    # Change the 'constant' value to the one user choosed.
-    change_flag_value "AUR_PACKAGE_MANAGER" "$aur_helper" "$AUR_SCRIPT_DIRECTORY/../../core/constants.sh"
+        # Change the 'constant' value to the one user choosed.
+        change_flag_value "AUR_PACKAGE_MANAGER" "$aur_helper"
 
     # Constant variables for installing and configuring the AUR helper.
     AUR_DIRECTORY="$aur_helper"

--- a/scripts/helpers/essentials/aur.sh
+++ b/scripts/helpers/essentials/aur.sh
@@ -22,7 +22,7 @@ source "$AUR_SCRIPT_DIRECTORY/../functions/ui.sh"
         change_flag_value "AUR_PACKAGE_MANAGER" "paru"
     elif command -v yay &>/dev/null; then
 
-        # Change the 'constant' value to "paru".
+        # Change the 'constant' value to "yay".
         aur_helper="yay"
         change_flag_value "AUR_PACKAGE_MANAGER" "yay"
     else
@@ -31,8 +31,9 @@ source "$AUR_SCRIPT_DIRECTORY/../functions/ui.sh"
         declare -a AUR_OPTIONS=("paru" "yay")
         aur_helper=$(choose_option "Choose an AUR helper" "${AUR_OPTIONS[@]}")
 
-        # Change the 'constant' value to the one user choosed.
+        # Change the 'constant' value to the one user chose.
         change_flag_value "AUR_PACKAGE_MANAGER" "$aur_helper"
+    fi
 
     # Constant variables for installing and configuring the AUR helper.
     AUR_DIRECTORY="$aur_helper"
@@ -79,7 +80,6 @@ source "$AUR_SCRIPT_DIRECTORY/../functions/ui.sh"
     makepkg -si --noconfirm
     cd ..
     rm -rf $AUR_DIRECTORY
-fi
 
 # Configure the AUR helper.
 case $aur_helper in

--- a/scripts/helpers/functions/state.sh
+++ b/scripts/helpers/functions/state.sh
@@ -15,36 +15,16 @@ change_flag_value() {
     # Ensure the state directory exists.
     mkdir -p "$STATE_DIRECTORY"
 
-    # If the state file doesn't exist, create it.
-    if [[ ! -f "$STATE_FILE" ]]; then
-        : > "$STATE_FILE"  # Empty file
-    fi
-
-    # Use a temporary file for atomic update.
+    # Write to a temporary file, then atomically replace the state file.
     local temp_file
-    temp_file=$(mktemp "$STATE_FILE.tmp.XXXXXX")
+    temp_file=$(mktemp "$STATE_DIRECTORY/.state.XXXXXX")
 
-    # Write the updated flag value.
+    # Drop any existing line for this flag, then append the new value.
+    grep -v "^$flag=" "$STATE_FILE" 2>/dev/null > "$temp_file" || true
     if [[ $value =~ ^[0-9]+$ ]]; then
-        # If it's an integer, don't add quotes.
-        if grep -q "^$flag=" "$STATE_FILE"; then
-            # Replace existing flag line
-            sed "s/^$flag=.*/$flag=$value/" "$STATE_FILE" > "$temp_file"
-        else
-            # Add new flag line
-            cat "$STATE_FILE" > "$temp_file"
-            echo "$flag=$value" >> "$temp_file"
-        fi
+        printf '%s=%s\n' "$flag" "$value" >> "$temp_file"
     else
-        # If it's not an integer, add quotes.
-        if grep -q "^$flag=" "$STATE_FILE"; then
-            # Replace existing flag line
-            sed "s/^$flag=.*/\"$flag=$value\"/" "$STATE_FILE" > "$temp_file"
-        else
-            # Add new flag line
-            cat "$STATE_FILE" > "$temp_file"
-            echo "$flag=\"$value\"" >> "$temp_file"
-        fi
+        printf '%s="%s"\n' "$flag" "$value" >> "$temp_file"
     fi
 
     # Atomically replace the state file.

--- a/scripts/helpers/functions/state.sh
+++ b/scripts/helpers/functions/state.sh
@@ -12,6 +12,12 @@ change_flag_value() {
     local flag="$1"
     local value="$2"
 
+    # Guard against values that could corrupt the state file.
+    if [[ $value == *\"* || $value == *\\* || $value == *$'\n'* ]]; then
+        echo "invalid value" >&2
+        return 1
+    fi
+
     # Ensure the state directory exists.
     mkdir -p "$STATE_DIRECTORY"
 
@@ -20,7 +26,7 @@ change_flag_value() {
     temp_file=$(mktemp "$STATE_DIRECTORY/.state.XXXXXX")
 
     # Drop any existing line for this flag, then append the new value.
-    grep -v "^$flag=" "$STATE_FILE" 2>/dev/null > "$temp_file" || true
+    grep -v -F -- "$flag=" "$STATE_FILE" 2>/dev/null > "$temp_file" || true
     if [[ $value =~ ^[0-9]+$ ]]; then
         printf '%s=%s\n' "$flag" "$value" >> "$temp_file"
     else

--- a/scripts/helpers/functions/state.sh
+++ b/scripts/helpers/functions/state.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# shellcheck disable=SC2034
+
+# Constant variable for the state directory and file.
+STATE_DIRECTORY="${ARCH_TUNER_STATE_DIRECTORY:-/var/lib/arch-tuner}"
+STATE_FILE="$STATE_DIRECTORY/state.sh"
+
+# Function to change a flag value to the given value in the state file.
+# change_flag_value "flag" "value"
+change_flag_value() {
+    local flag="$1"
+    local value="$2"
+
+    # Ensure the state directory exists.
+    mkdir -p "$STATE_DIRECTORY"
+
+    # If the state file doesn't exist, create it.
+    if [[ ! -f "$STATE_FILE" ]]; then
+        : > "$STATE_FILE"  # Empty file
+    fi
+
+    # Use a temporary file for atomic update.
+    local temp_file
+    temp_file=$(mktemp "$STATE_FILE.tmp.XXXXXX")
+
+    # Write the updated flag value.
+    if [[ $value =~ ^[0-9]+$ ]]; then
+        # If it's an integer, don't add quotes.
+        if grep -q "^$flag=" "$STATE_FILE"; then
+            # Replace existing flag line
+            sed "s/^$flag=.*/$flag=$value/" "$STATE_FILE" > "$temp_file"
+        else
+            # Add new flag line
+            cat "$STATE_FILE" > "$temp_file"
+            echo "$flag=$value" >> "$temp_file"
+        fi
+    else
+        # If it's not an integer, add quotes.
+        if grep -q "^$flag=" "$STATE_FILE"; then
+            # Replace existing flag line
+            sed "s/^$flag=.*/\"$flag=$value\"/" "$STATE_FILE" > "$temp_file"
+        else
+            # Add new flag line
+            cat "$STATE_FILE" > "$temp_file"
+            echo "$flag=\"$value\"" >> "$temp_file"
+        fi
+    fi
+
+    # Atomically replace the state file.
+    mv "$temp_file" "$STATE_FILE"
+}
+
+# Function to source the state file if it exists.
+# source_state
+source_state() {
+    if [[ -f "$STATE_FILE" ]]; then
+        # shellcheck disable=SC1090
+        source "$STATE_FILE"
+    fi
+}
+
+# Function to remove the state file.
+# reset_state
+reset_state() {
+    if [[ -f "$STATE_FILE" ]]; then
+        rm -f "$STATE_FILE"
+    fi
+}

--- a/scripts/helpers/functions/strings.sh
+++ b/scripts/helpers/functions/strings.sh
@@ -10,22 +10,3 @@ STRINGS_SCRIPT_DIRECTORY=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 trim_string() {
     echo "$1" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
 }
-
-# Function to change a flag value to the given value.
-# change_flag_value "flag" "value" "script_path"
-change_flag_value() {
-    local flag=$1
-    local value=$2
-    local script_path=$3
-
-    # Check if the value is an integer.
-    if [[ $value =~ ^[0-9]+$ ]]; then
-
-        # If it's an integer, don't add quotes.
-        sed -i "s/^$flag=.*\$/$flag=$value/" "$script_path"
-    else
-
-        # If it's not an integer, add quotes.
-        sed -i "s/^$flag=.*\$/$flag=\"$value\"/" "$script_path"
-    fi
-}

--- a/scripts/helpers/functions/system.sh
+++ b/scripts/helpers/functions/system.sh
@@ -142,9 +142,6 @@ reboot_system() {
     # Defaults to 0 (true) to log the warning.
     local log_rerun_warning="${3:-0}"
 
-    # Constant variable for the flags script path.
-    FLAGS_PATH="$SYSTEM_SCRIPT_DIRECTORY/../../core/flags.sh"
-
     # Check the value is not equal to 0 (true) and reboot.
     if [ "$flag" -ne 0 ]; then
         log_error "System requires a reboot to apply changes!"
@@ -166,10 +163,6 @@ reboot_system() {
 # Usage:
 #   reset_system_to_clean_state
 reset_system_to_clean_state() {
-
-    # Constant variable for the flags script path.
-    FLAGS_PATH="$SYSTEM_SCRIPT_DIRECTORY/../../core/flags.sh"
-    CONSTANTS_PATH="$SYSTEM_SCRIPT_DIRECTORY/../../core/constants.sh"
 
     # URL of a fresh Arch Linux installation package list.
     PACKAGE_LIST_URL="https://geo.mirror.pkgbuild.com/iso/latest/arch/pkglist.x86_64.txt"

--- a/scripts/helpers/functions/system.sh
+++ b/scripts/helpers/functions/system.sh
@@ -6,6 +6,7 @@ SYSTEM_SCRIPT_DIRECTORY=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # Import log functions and flags.
 source "$SYSTEM_SCRIPT_DIRECTORY/logs.sh"
 source "$SYSTEM_SCRIPT_DIRECTORY/strings.sh"
+source "$SYSTEM_SCRIPT_DIRECTORY/state.sh"
 source "$SYSTEM_SCRIPT_DIRECTORY/../../core/flags.sh"
 
 # ? Importing constants.sh is not needed, because it is already sourced in the logs script.
@@ -154,7 +155,7 @@ reboot_system() {
         sleep 10
 
         # Change the value of the flag to 0 (true), before rebooting.
-        change_flag_value "$flag_name" 0 "$FLAGS_PATH"
+        change_flag_value "$flag_name" 0
 
         # Reboot the system immediately.
         exec sudo reboot
@@ -283,14 +284,14 @@ reset_system_to_clean_state() {
     fi
 
     # Change the value of the flag to 0 (true).
-    change_flag_value "$SYSTEM_RESET" 0 "$FLAGS_PATH"
+    change_flag_value "$SYSTEM_RESET" 0
 
     # Reset core/constants and core/flags files too.
-    change_flag_value "$INSTALLATION_TYPE" "server" "$CONSTANTS_PATH"
-    change_flag_value "$AUR_PACKAGE_MANAGER" "" "$CONSTANTS_PATH"
-    change_flag_value "$ESSENTIALS_COMPLETED" 1 "$FLAGS_PATH"
-    change_flag_value "$SECURITY_COMPLETED" 1 "$FLAGS_PATH"
-    change_flag_value "$PRIVACY_COMPLETED" 1 "$FLAGS_PATH"
+    change_flag_value "$INSTALLATION_TYPE" "server"
+    change_flag_value "$AUR_PACKAGE_MANAGER" ""
+    change_flag_value "$ESSENTIALS_COMPLETED" 1
+    change_flag_value "$SECURITY_COMPLETED" 1
+    change_flag_value "$PRIVACY_COMPLETED" 1
 
     log_success "System reset to a clean Arch Linux installation state!"
 }


### PR DESCRIPTION
## Summary

Stops the toolkit from mutating its own source files at runtime. Completion flags and runtime-set values (AUR_PACKAGE_MANAGER) previously lived in `scripts/core/flags.sh` and `scripts/core/constants.sh` via sed at runtime; they now live in `/var/lib/arch-tuner/state.sh`.

## Changes

- New `scripts/helpers/functions/state.sh`: `change_flag_value <flag> <value>` (atomic write via temp file + mv, idempotent via grep -v then append), `source_state`, `reset_state`. `ARCH_TUNER_STATE_DIRECTORY` env override for testing.
- Removed the old `change_flag_value` from `strings.sh`.
- Updated all call sites (system.sh, aur.sh, install.sh) to the 2-arg signature.
- `flags.sh` and `constants.sh` are now documented defaults/static values, never rewritten at runtime.
- `install.sh` sources state after the library loads so runtime values override defaults.

## Verification

- shellcheck and `bash -n` clean repo-wide.
- Functional tests: idempotent integer and string flag writes, quoting, state-overrides-defaults, reset.