### PR TITLE
security: harden pacman signature verification and AUR cleanup

### DIFF
--- a/scripts/helpers/essentials/aur.sh
+++ b/scripts/helpers/essentials/aur.sh
@@ -89,7 +89,17 @@ paru)
     declare -a CONFIGURATION_OPTIONS=("BottomUp" "Devel" "Provides" "PgpFetch" "CombinedUpgrade" "FailFast" "SudoLoop" "SkipReview")
 
     # Constant variable for the paru AUR helper configuration file.
-    PARU_CONFIGURATION="/etc/paru.conf"
+    PARU_CONFIGURATION="$HOME/.config/paru/paru.conf"
+
+    # Add CleanMethod = KeepInstalled to paru configuration.
+    if [ -f "$PARU_CONFIGURATION" ]; then
+        if ! grep -qxF "CleanMethod = KeepInstalled" "$PARU_CONFIGURATION"; then
+            log_info "Adding CleanMethod = KeepInstalled to $aur_helper configuration..."
+            echo "CleanMethod = KeepInstalled" | sudo tee -a "$PARU_CONFIGURATION" >/dev/null
+        else
+            log_info "CleanMethod = KeepInstalled already configured."
+        fi
+    fi
 
     # Check if at least one configuration option does not exist or is commented out.
     configuration_option_missing=false

--- a/scripts/helpers/essentials/pacman.sh
+++ b/scripts/helpers/essentials/pacman.sh
@@ -21,6 +21,12 @@ if ! grep -q '^Color' "$PACMAN_CONFIGURATION" || ! grep -q '^ParallelDownloads' 
     log_info "Configuring $ARCH_PACKAGE_MANAGER package manager..."
 fi
 
+# Add pacman signature hardening.
+source "$PACMAN_SCRIPT_DIRECTORY/../functions/filesystem.sh"
+if ! append_line_to_file "$PACMAN_CONFIGURATION" "SigLevel = Required DatabaseOptional TrustedOnly" "Adding pacman signature hardening..."; then
+    log_info "Pacman signature hardening already configured."
+fi
+
 # Enable colors in terminal.
 # TODO: Try using the `change_configuration` function.
 if ! grep -q '^Color' $PACMAN_CONFIGURATION; then

--- a/scripts/packages/security/pacman.txt
+++ b/scripts/packages/security/pacman.txt
@@ -1,0 +1,1 @@
+pacman-contrib


### PR DESCRIPTION
Adds SigLevel enforcement and paru CleanMethod. Config payloads only, no security.sh wiring (per parallel-safety rule).