### PR TITLE
Add prompt_user_input function to ui.sh

### DIFF
--- a/scripts/helpers/functions/ui.sh
+++ b/scripts/helpers/functions/ui.sh
@@ -166,3 +166,22 @@ choose_option() {
         fi
     done
 }
+
+# Function to prompt user for input with a default value.
+# Usage:
+#   prompt_user_input "prompt_message" "default_value"
+prompt_user_input() {
+    local prompt="$1"
+    local default_value="$2"
+    local input=""
+
+    log_info -n "$prompt [$default_value]: "
+    read -r input
+
+    # Use default value if input is empty.
+    if [ -z "$input" ]; then
+        input="$default_value"
+    fi
+
+    echo "$input"
+}


### PR DESCRIPTION
**What**:

1. Add the missing `prompt_user_input` function to `scripts/helpers/functions/ui.sh`.

**Why**:

`scripts/helpers/security/user.sh` calls `prompt_user_input`, which was never defined, and CI doesn't execute the scripts so the gap went unnoticed.