### PR TITLE
Broaden README from VPS-only to any server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Arch VPS Hardening Toolkit
+# Arch Server Hardening Toolkit
 
-An Arch Linux VPS hardening toolkit for securing and hardening your Arch-based Virtual Private Server. Originally evolved from an Arch desktop post-install toolkit, this project is now focused exclusively on server hardening.
+An Arch Linux server hardening toolkit for securing and hardening your Arch-based server, whether a VPS, a cloud instance, or bare metal. Originally evolved from an Arch desktop post-install toolkit, this project is now focused exclusively on server hardening.
 
 See [`AGENTS.md`](AGENTS.md) if you are an agent.
 
 ## Why Server-Only
 
-This toolkit is purpose-built for Arch VPS deployments, focusing on essential security hardening, privacy protection, and system essentials. Features that were relevant for desktop systems have been removed to keep the toolkit lean and secure for server environments.
+This toolkit is purpose-built for Arch server deployments, whether a VPS, a cloud instance, or bare metal, focusing on essential security hardening, privacy protection, and system essentials. Features that were relevant for desktop systems have been removed to keep the toolkit lean and secure for server environments.
 
 Desktop-specific components like display managers, graphical login interfaces, and desktop environments have all been removed.
 


### PR DESCRIPTION
**What**:

1. Retitle `README.md` from "Arch VPS Hardening Toolkit" to "Arch Server Hardening Toolkit".
2. Reword the intro and "Why Server-Only" paragraphs to name VPS, cloud instance, and bare metal as examples of what this hardens, instead of framing VPS as the only target.

**Why**:

Nothing in this toolkit is actually VPS-specific, it hardens any Arch server. The README's own wording narrowed that to VPS only, which undersells what it covers.