### PR TITLE
Pin CI actions to SHA and scope token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,14 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Install shellcheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
       - name: Run shellcheck on scripts
@@ -20,24 +23,24 @@ jobs:
   bash-syntax:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Run bash -n on scripts
         run: find scripts -name '*.sh' -type f -exec bash -n {} \; && bash -n install.sh
 
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   markdownlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Install markdownlint-cli
         run: npm install -g markdownlint-cli
       - name: Run markdownlint


### PR DESCRIPTION
## What
Pins every `actions/checkout` and `gitleaks/gitleaks-action` step in `.github/workflows/ci.yml` to a commit `SHA` (with the version as a trailing comment) instead of a mutable tag, and adds a top-level `permissions: contents: read` block.

## Why
Tags like `@v4` and `@v2` can be moved to point at different code without notice, a supply-chain risk for anything running in CI with a `GITHUB_TOKEN`. No job here writes anything, so scoping the token to `contents: read` follows least privilege.