### PR TITLE
Pin rev for pre-commit hook repositories

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,15 @@
 - repo: https://github.com/koalaman/shellcheck-precommit
+  rev: v0.11.0
   hooks:
     - id: shellcheck
       args: [-x, -S, warning]
 
 - repo: https://github.com/gitleaks/gitleaks
+  rev: v8.30.1
   hooks:
     - id: gitleaks
 
 - repo: https://github.com/igorshubovych/markdownlint-cli
+  rev: v0.49.1
   hooks:
     - id: markdownlint


### PR DESCRIPTION
## What
Adds a pinned `rev` to each of the three hook repositories in `.pre-commit-config.yaml`: `shellcheck-precommit` (`v0.11.0`), `gitleaks` (`v8.30.1`), and `markdownlint-cli` (`v0.49.1`).

## Why
`pre-commit`'s schema requires a `rev` field for every non-local repository. Without one, `pre-commit install` and `pre-commit run` fail validation, so the file as written could not actually be used to install hooks locally.