### PR TITLE
Add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## What
Adds `.github/dependabot.yml` with a `github-actions` ecosystem entry, checked weekly.

## Why
`.github/workflows/ci.yml` now pins actions to a commit `SHA`, nothing previously kept those pins current. `Dependabot` opens a `PR` bumping both the `SHA` and its version comment whenever a new release ships.