### PR TITLE
Replace eval in ask_user_before_execution

### DIFF
--- a/scripts/helpers/functions/ui.sh
+++ b/scripts/helpers/functions/ui.sh
@@ -101,7 +101,7 @@ ask_user_before_execution() {
                     sh "$script_or_function_or_command"
                 else
                     # It's a plain command, so execute it.
-                    eval "$script_or_function_or_command ${arguments[*]}"
+                    "$script_or_function_or_command" "${arguments[@]}"
                 fi
             else
                 log_error "Invalid script or function or command: $script_or_function_or_command"


### PR DESCRIPTION
## What
Replaces `eval "$script_or_function_or_command ${arguments[*]}"` in the plain-command branch of `ask_user_before_execution` (`scripts/helpers/functions/ui.sh`) with a direct array invocation, `"$script_or_function_or_command" "${arguments[@]}"`.

## Why
`eval` re-parses its argument as shell input, so arguments get word-split and re-interpreted instead of passed through as-is. No current caller in `install.sh` exercises this plain-command branch with arguments, but it is a shared, unsanitized "run anything" primitive, and a direct array call gets the same result without ever handing a string back to the shell for re-evaluation.