### PR TITLE
Build find command as an array in ids.sh

### DIFF
--- a/scripts/helpers/security/ids.sh
+++ b/scripts/helpers/security/ids.sh
@@ -42,24 +42,24 @@ declare -a EXCLUDE_PATHS=(
 )
 
 # Start with the basic command.
-FIND_COMMAND="sudo find /"
+FIND_COMMAND=(sudo find /)
 
 # Then we add each excluded path.
 for path in "${EXCLUDE_PATHS[@]}"; do
 
     # If this is not the last path in EXCLUDE_PATHS add the '-o' otherwise omit it.
     if [[ "$path" != "${EXCLUDE_PATHS[-1]}" ]]; then
-        FIND_COMMAND="${FIND_COMMAND} -path $path -prune -o"
+        FIND_COMMAND+=(-path "$path" -prune -o)
     else
-        FIND_COMMAND="${FIND_COMMAND} -path $path -prune"
+        FIND_COMMAND+=(-path "$path" -prune)
     fi
 done
 
 # Finally, we add the part that selects the files of interest.
-FIND_COMMAND="${FIND_COMMAND} -o -type f \( -perm -4000 -o -perm -2000 \) -print"
+FIND_COMMAND+=(-o -type f "(" -perm -4000 -o -perm -2000 ")" -print)
 
 # Execute the final command.
-suid_sgid_binary_files=$(eval $FIND_COMMAND 2>&1 | grep -v "File system loop detected" || true)
+suid_sgid_binary_files=$("${FIND_COMMAND[@]}" 2>&1 | grep -v "File system loop detected" || true)
 if [[ -z "$suid_sgid_binary_files" ]]; then
     log_info "No SUID/SGID binaries found!"
     exit 0


### PR DESCRIPTION
## What
Rebuilds `FIND_COMMAND` in `scripts/helpers/security/ids.sh` as a bash array instead of a string, and runs it directly (`"${FIND_COMMAND[@]}"`) instead of `eval $FIND_COMMAND`. Same excluded paths, same `-prune`/`-o` structure, same grouped permission test.

## Why
The previous version built a command string from `EXCLUDE_PATHS` and handed it to `eval`, which re-parses the string as shell input. No external input reaches `FIND_COMMAND` today, but building and `eval`-ing a string is unnecessary and fragile compared to an array, which passes each argument through exactly once with no re-parsing.