### PR TITLE
Quote AUR_GIT_URL and AUR_DIRECTORY in aur.sh

### DIFF
--- a/scripts/helpers/essentials/aur.sh
+++ b/scripts/helpers/essentials/aur.sh
@@ -75,11 +75,11 @@ source "$AUR_SCRIPT_DIRECTORY/../functions/ui.sh"
 
     # Proceed with installation.
     log_info "Installing $aur_helper AUR helper..."
-    git clone $AUR_GIT_URL
-    cd $AUR_DIRECTORY
+    git clone "$AUR_GIT_URL"
+    cd "$AUR_DIRECTORY"
     makepkg -si --noconfirm
     cd ..
-    rm -rf $AUR_DIRECTORY
+    rm -rf "$AUR_DIRECTORY"
 
 # Configure the AUR helper.
 case $aur_helper in


### PR DESCRIPTION
## What
Quotes `$AUR_GIT_URL` and `$AUR_DIRECTORY` in the `git clone`, `cd`, and `rm -rf` calls in `scripts/helpers/essentials/aur.sh`.

## Why
Both variables were unquoted. `AUR_DIRECTORY` only ever holds `paru` or `yay` today, so there is no live bug, but leaving them unquoted invites word-splitting and glob expansion if either variable's construction ever changes, and is inconsistent with the quoting discipline the rest of the codebase follows.