### PR TITLE
Fix `append_line_to_file` always echoing `false` after `true`

### DIFF
--- a/scripts/helpers/functions/filesystem.sh
+++ b/scripts/helpers/functions/filesystem.sh
@@ -29,6 +29,7 @@ append_line_to_file() {
 
         # Return true to indicate that a change was made.
         echo "true"
+        return
     fi
 
     # Return false to indicate that no change was made.


### PR DESCRIPTION
**What**
`append_line_to_file` in `scripts/helpers/functions/filesystem.sh` echoes `"true"` when it appends a line, but had no `return`, so it always fell through and also echoed `"false"` right after. Any caller capturing `$(append_line_to_file ...)` got the literal string `"true\nfalse"`, which never equals `"true"`.

**Why**
This silently broke every caller that branches on the result. Concretely, all 12 call sites in `scripts/helpers/security/antivirus.sh` never detect that a line was appended, so `clamonacc` (real-time `ClamAV` scanning) is never restarted after `clamd.conf` is updated.