### PR TITLE
Fix `/etc/fstab` symlink race in `update_mount_options`

### DIFF
--- a/scripts/helpers/functions/filesystem.sh
+++ b/scripts/helpers/functions/filesystem.sh
@@ -69,7 +69,9 @@ update_mount_options() {
         # Update the fstab entry if necessary.
         if [[ "$modified_options" != "$current_options" ]]; then
             log_info "Appending options $options to mount point $mount_point..."
-            sudo awk -v mount="$mount_point" -v opts="$modified_options" '\
+            local temp_fstab
+            temp_fstab=$(sudo mktemp /etc/fstab.tmp.XXXXXX)
+            if sudo awk -v mount="$mount_point" -v opts="$modified_options" '\
             {\
                 # If the line contains the target mount point and is not commented\
                 if ($2 == mount && $1 !~ /^#/) {\
@@ -79,7 +81,13 @@ update_mount_options() {
                 # Print each line (modified or not)\
                 print\
             }\
-            ' /etc/fstab | sudo tee /tmp/fstab.tmp >/dev/null && sudo mv /tmp/fstab.tmp /etc/fstab
+            ' /etc/fstab | sudo tee "$temp_fstab" >/dev/null; then
+                sudo chmod 644 "$temp_fstab"
+                sudo chown root:root "$temp_fstab"
+                sudo mv "$temp_fstab" /etc/fstab
+            else
+                sudo rm -f "$temp_fstab"
+            fi
 
             # Return true to indicate that a change was made.
             echo "true"


### PR DESCRIPTION
**What**
`update_mount_options` wrote the rewritten `/etc/fstab` contents to a fixed, predictable path (`/tmp/fstab.tmp`) via `sudo tee`, then `sudo mv`d it into place. It now writes to a unique path created by `sudo mktemp` under `/etc` (root-owned directory, atomic `O_EXCL` creation), then explicitly sets `644 root:root` before the move, matching the permissions/ownership `/etc/fstab` requires. On failure the temp file is removed instead of left behind.

**Why**
`/tmp` is world-writable. A fixed, predictable temp filename there lets a local attacker pre-create `/tmp/fstab.tmp` as a symlink to an arbitrary file (e.g. `/etc/shadow` or `/etc/sudoers`); since the write runs via `sudo tee`, root would follow the symlink and clobber the target, a TOCTOU privilege-escalation path in code whose whole job is editing a security-relevant file.