### PR TITLE
Fix `reset_system_to_clean_state` passing flag values as names

### DIFF
--- a/scripts/helpers/functions/system.sh
+++ b/scripts/helpers/functions/system.sh
@@ -277,14 +277,14 @@ reset_system_to_clean_state() {
     fi
 
     # Change the value of the flag to 0 (true).
-    change_flag_value "$SYSTEM_RESET" 0
+    change_flag_value "SYSTEM_RESET" 0
 
     # Reset core/constants and core/flags files too.
-    change_flag_value "$INSTALLATION_TYPE" "server"
-    change_flag_value "$AUR_PACKAGE_MANAGER" ""
-    change_flag_value "$ESSENTIALS_COMPLETED" 1
-    change_flag_value "$SECURITY_COMPLETED" 1
-    change_flag_value "$PRIVACY_COMPLETED" 1
+    change_flag_value "INSTALLATION_TYPE" "server"
+    change_flag_value "AUR_PACKAGE_MANAGER" ""
+    change_flag_value "ESSENTIALS_COMPLETED" 1
+    change_flag_value "SECURITY_COMPLETED" 1
+    change_flag_value "PRIVACY_COMPLETED" 1
 
     log_success "System reset to a clean Arch Linux installation state!"
 }


### PR DESCRIPTION
**What**
`reset_system_to_clean_state` called `change_flag_value` with each flag's current *value* (e.g. `"$SYSTEM_RESET"`) as the *flag name* argument, instead of the literal flag name. It now passes the literal names, matching the correct call pattern already used at `install.sh:84,87` and `scripts/helpers/essentials/aur.sh:22`.

**Why**
`change_flag_value(flag, value)` writes `$flag=$value` into `/var/lib/arch-tuner/state.sh`. With the value passed as the name, e.g. `change_flag_value "$SYSTEM_RESET" 0` where `SYSTEM_RESET=1`, the state file got a garbage line like `1=0` instead of `SYSTEM_RESET=0`, so none of the real flags were actually reset on this path.