### PR TITLE
Add `bats-core` regression tests for state/filesystem fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,12 @@ jobs:
         run: npm install -g markdownlint-cli
       - name: Run markdownlint
         run: markdownlint README.md --config .markdownlint.json
+
+  bats:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - name: Install bats
+        run: sudo apt-get update && sudo apt-get install -y bats
+      - name: Run bats tests
+        run: bats test/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,7 @@ find scripts -name '*.sh' -type f -exec bash -n {} \;
 bash -n install.sh
 markdownlint README.md --config .markdownlint.json
 grep -rn "keyboard\|kloak" scripts/ || true
+bats test/
 ```
 
 ## Security

--- a/test/filesystem.bats
+++ b/test/filesystem.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+
+setup() {
+    filesystem_under_test="$BATS_TEST_DIRNAME/../scripts/helpers/functions/filesystem.sh"
+
+    # Stub sudo so the sourced functions run as the test user against files
+    # already owned by that user, instead of requiring real root.
+    sudo() { command "$@"; }
+    export -f sudo
+
+    source "$filesystem_under_test"
+}
+
+@test "append_line_to_file appends a missing line and prints only true" {
+    local file="$BATS_TEST_TMPDIR/target.txt"
+    : >"$file"
+
+    run append_line_to_file "$file" "hello world" ""
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "true" ]
+    grep -qxF "hello world" "$file"
+}
+
+@test "append_line_to_file skips an existing line and prints only false" {
+    local file="$BATS_TEST_TMPDIR/target.txt"
+    echo "hello world" >"$file"
+
+    run append_line_to_file "$file" "hello world" ""
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "false" ]
+}
+
+@test "update_mount_options no longer writes fstab to a fixed /tmp path" {
+    ! grep -q '/tmp/fstab.tmp' "$filesystem_under_test"
+    grep -q 'mktemp' "$filesystem_under_test"
+}

--- a/test/state.bats
+++ b/test/state.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+
+setup() {
+    state_under_test="$BATS_TEST_DIRNAME/../scripts/helpers/functions/state.sh"
+    system_under_test="$BATS_TEST_DIRNAME/../scripts/helpers/functions/system.sh"
+
+    export ARCH_TUNER_STATE_DIRECTORY="$BATS_TEST_TMPDIR"
+    source "$state_under_test"
+}
+
+@test "change_flag_value writes the literal flag name and value" {
+    change_flag_value "EXAMPLE_FLAG" "1"
+
+    grep -qxF 'EXAMPLE_FLAG=1' "$STATE_FILE"
+}
+
+@test "change_flag_value overwrites an existing flag rather than duplicating it" {
+    change_flag_value "EXAMPLE_FLAG" "0"
+    change_flag_value "EXAMPLE_FLAG" "1"
+
+    [ "$(grep -c '^EXAMPLE_FLAG=' "$STATE_FILE")" -eq 1 ]
+    grep -qxF 'EXAMPLE_FLAG=1' "$STATE_FILE"
+}
+
+@test "reset_system_to_clean_state calls change_flag_value with literal flag names" {
+    # Regression guard for the value/name argument-swap bug: every
+    # change_flag_value call inside the function must pass a literal name,
+    # never a variable expansion like "$SOME_FLAG".
+    function_body=$(awk '/^reset_system_to_clean_state\(\)/,/^}/' "$system_under_test")
+
+    ! grep -E 'change_flag_value "\$[A-Z_]+"' <<<"$function_body"
+}


### PR DESCRIPTION
**What**
Introduces `bats-core` and a `test/` directory with regression tests for `append_line_to_file`, the `/etc/fstab` temp-file handling in `update_mount_options`, `change_flag_value`, and the flag-name usage inside `reset_system_to_clean_state`. Adds a `bats` job to `.github/workflows/ci.yml` and the `bats test/` command to the `AGENTS.md` verification checklist.

**Why**
CI today is entirely static analysis (`shellcheck`, `bash -n`, `gitleaks`, `markdownlint`), so it cannot catch functional/logic bugs. Two recently merged fixes (`append_line_to_file` always returning `false`, and `reset_system_to_clean_state` passing flag values as names) were exactly that kind of bug and would have passed every existing CI check. These tests were verified against the pre-fix commit to confirm they actually fail without the fixes and pass with them, so future regressions of the same shape get caught automatically.