### PR TITLE
Restore per-phase approval prompt in `install.sh`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,9 +16,9 @@ declare -a ORDERED_SCRIPTS=("essentials" "privacy" "security")
 
 # Scripts to run containing their completion flag, initial setup value and optional message, splitted by "|".
 declare -A SCRIPTS=(
-    ["essentials"]="ESSENTIALS_COMPLETED|1"
-    ["privacy"]="PRIVACY_COMPLETED|1"
-    ["security"]="SECURITY_COMPLETED|1"
+    ["essentials"]="ESSENTIALS_COMPLETED|1|Would you like to run the essentials setup script?"
+    ["privacy"]="PRIVACY_COMPLETED|1|Would you like to run the privacy setup script?"
+    ["security"]="SECURITY_COMPLETED|1|Would you like to run the security setup script?"
 )
 
 # Import functions and flags.


### PR DESCRIPTION
**What**
Each entry in the `SCRIPTS` associative array only carried 2 of the documented 3 `|`-delimited fields (completion flag, initial setup value), but the loop reads a 3rd field as the phase confirmation `message`. Adds that field back with a per-phase prompt.

**Why**
With `message` always empty, `if [[ "$message" ]]` was always false, so every phase (`essentials`, `privacy`, `security`) silently auto-ran via the `else` branch instead of asking for approval first, contradicting the confirm-before-each-phase behavior the rest of the script (backup confirmation, system reset confirmation) already follows.