### PR TITLE
Quote `$package` in `reset_system_to_clean_state` loops

### DIFF
--- a/scripts/helpers/functions/system.sh
+++ b/scripts/helpers/functions/system.sh
@@ -250,15 +250,15 @@ reset_system_to_clean_state() {
     # Mark essential packages as explicitly installed.
     log_info "Excluding essential packages from removal..."
     for package in "${ESSENTIAL_PACKAGES[@]}"; do
-        if pacman -Q $package &> /dev/null; then
-            sudo $ARCH_PACKAGE_MANAGER -D --asexplicit $package
+        if pacman -Q "$package" &> /dev/null; then
+            sudo $ARCH_PACKAGE_MANAGER -D --asexplicit "$package"
         fi
     done
 
     log_info "Excluding fresh installation packages from removal..."
     for package in $FRESH_INSTALLATION_PACKAGES; do
-        if pacman -Q $package &> /dev/null; then
-            sudo $ARCH_PACKAGE_MANAGER -D --asexplicit $package
+        if pacman -Q "$package" &> /dev/null; then
+            sudo $ARCH_PACKAGE_MANAGER -D --asexplicit "$package"
         fi
     done
 


### PR DESCRIPTION
**What**
Quotes `$package` in the `pacman -Q`/`--asexplicit` calls inside both loops in `reset_system_to_clean_state`.

**Why**
Values come from a hardcoded array or the downloaded package list rather than direct user input, so practical risk is low, but unquoted variables break word-splitting/glob safety and are inconsistent with the quoting convention used elsewhere in this function.