### PR TITLE
Batch `are_packages_installed` package-manager queries

### DIFF
--- a/scripts/helpers/functions/packages.sh
+++ b/scripts/helpers/functions/packages.sh
@@ -19,26 +19,24 @@ are_packages_installed() {
     local package_manager="$2"
     local package_not_found=0
 
-    # Initialize the query command.
-    local query_command=""
-
-    # Determine the installation command based on the chosen package manager.
-    case "$package_manager" in
-    "$AUR_PACKAGE_MANAGER")
-        query_command="$AUR_PACKAGE_MANAGER -Qq"
-        ;;
-    "$ARCH_PACKAGE_MANAGER")
-        query_command="$ARCH_PACKAGE_MANAGER -Qq"
-        ;;
-    "")
-        # If no package manager is specified, we'll use `command -V`.
-        query_command="command -v"
-        ;;
-    *)
-        log_error "Unsupported package manager: '$package_manager'"
-        exit 1
-        ;;
-    esac
+    # For a real package manager, list all installed packages once instead of
+    # shelling out per package below. If no package manager is specified,
+    # each package is checked individually via `command -v` below instead.
+    local -A installed_packages_set=()
+    if [ -n "$package_manager" ]; then
+        case "$package_manager" in
+        "$AUR_PACKAGE_MANAGER" | "$ARCH_PACKAGE_MANAGER")
+            local installed_package
+            while IFS= read -r installed_package; do
+                installed_packages_set["$installed_package"]=1
+            done < <("$package_manager" -Qq)
+            ;;
+        *)
+            log_error "Unsupported package manager: '$package_manager'"
+            exit 1
+            ;;
+        esac
+    fi
 
     # Check if the argument is a file.
     if [ -f "$input" ]; then
@@ -59,7 +57,11 @@ are_packages_installed() {
         fi
 
         # Check if the package is already installed.
-        if ! $query_command "$package" >/dev/null 2>&1; then
+        if [ -n "$package_manager" ]; then
+            if [[ -z "${installed_packages_set[$package]+x}" ]]; then
+                package_not_found=1
+            fi
+        elif ! command -v "$package" >/dev/null 2>&1; then
             package_not_found=1
         fi
     done

--- a/test/packages.bats
+++ b/test/packages.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+
+setup() {
+    packages_under_test="$BATS_TEST_DIRNAME/../scripts/helpers/functions/packages.sh"
+
+    fake_bin="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$fake_bin"
+    calls_log="$BATS_TEST_TMPDIR/calls.log"
+    : >"$calls_log"
+
+    cat >"$fake_bin/fakepacman" <<EOF
+#!/usr/bin/env bash
+echo "call: \$*" >> "$calls_log"
+if [ "\$1" = "-Qq" ]; then
+    printf 'bash\ngit\ncurl\n'
+fi
+EOF
+    chmod +x "$fake_bin/fakepacman"
+    PATH="$fake_bin:$PATH"
+
+    source "$BATS_TEST_DIRNAME/../scripts/helpers/functions/logs.sh"
+    source "$BATS_TEST_DIRNAME/../scripts/helpers/functions/strings.sh"
+    source "$packages_under_test"
+}
+
+@test "are_packages_installed shells out to the package manager only once" {
+    ARCH_PACKAGE_MANAGER="fakepacman"
+
+    run are_packages_installed "bash git curl" "fakepacman"
+
+    [ "$output" = "true" ]
+    [ "$(wc -l <"$calls_log" | tr -d ' ')" -eq 1 ]
+}
+
+@test "are_packages_installed detects a missing package" {
+    ARCH_PACKAGE_MANAGER="fakepacman"
+
+    run are_packages_installed "bash missing-package" "fakepacman"
+
+    [ "$output" = "false" ]
+}
+
+@test "are_packages_installed falls back to command -v when no package manager is given, even with an empty AUR_PACKAGE_MANAGER" {
+    AUR_PACKAGE_MANAGER=""
+
+    run are_packages_installed "bash ls" "$AUR_PACKAGE_MANAGER"
+
+    [ "$output" = "true" ]
+    [ ! -s "$calls_log" ]
+}


### PR DESCRIPTION
**What**
`are_packages_installed` shelled out to the package manager once per package (`pacman -Qq <package>`) instead of once total. It now lists all installed packages with a single `-Qq` call up front and checks membership in-process. Also fixes a latent case-statement ambiguity: when `AUR_PACKAGE_MANAGER` is empty (no AUR helper installed yet, a real state per `cpu.sh`/`terminal.sh` callers) and the "no package manager" (`command -v`) path is requested, an empty `package_manager` argument matched the AUR case pattern instead of the intended `command -v` branch, firing a stray failing subprocess. Adds `bats-core` regression tests for both.

**Why**
For a package list of N entries this cuts N `pacman` invocations down to 1, real but modest given the small package-list sizes in this repo. The case-statement fix was found and confirmed while testing the batching change, in the same code block, so it is included here rather than as a separate PR that would conflict with this one.