### PR TITLE
Validate username before `useradd`/`passwd` in `user.sh`

### DIFF
--- a/scripts/helpers/security/user.sh
+++ b/scripts/helpers/security/user.sh
@@ -13,8 +13,17 @@ USER_SCRIPT_DIRECTORY=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 source "$USER_SCRIPT_DIRECTORY/../functions/logs.sh"
 source "$USER_SCRIPT_DIRECTORY/../functions/ui.sh"
 
-# Prompt for the administrative username.
-username=$(prompt_user_input "Enter username for administrative user" "admin")
+# Prompt for the administrative username, requiring a valid Linux username as defense-in-depth
+# before it reaches `useradd`/`passwd`.
+while :; do
+    username=$(prompt_user_input "Enter username for administrative user" "admin")
+
+    if [[ "$username" =~ ^[a-z_][a-z0-9_-]{0,31}$ ]]; then
+        break
+    fi
+
+    log_error "Invalid username: '$username'. Use up to 32 lowercase letters, digits, underscores, or hyphens, starting with a letter or underscore."
+done
 
 # Check if the user already exists.
 if id "$username" &>/dev/null; then


### PR DESCRIPTION
**What**
The admin username from `prompt_user_input` was passed straight to `useradd`/`passwd` with no validation. It now loops until the input matches a standard Linux username pattern (lowercase letters/digits/underscores/hyphens, starting with a letter or underscore, up to 32 characters), re-prompting with an error on invalid input.

**Why**
`useradd` itself rejects genuinely dangerous names, so injection risk was already negligible, but this is admin-facing setup code creating a `wheel`-group user with no explicit input validation. Verified on a real Arch Linux container: rejects `Invalid Name!` and `../etc/passwd` with a clear error and re-prompts, then accepts a valid name and creates the user correctly.