### PR TITLE
Document unsigned AUR risk and guard against a bad clone in `aur.sh`

### DIFF
--- a/scripts/helpers/essentials/aur.sh
+++ b/scripts/helpers/essentials/aur.sh
@@ -74,9 +74,17 @@ source "$AUR_SCRIPT_DIRECTORY/../functions/ui.sh"
     esac
 
     # Proceed with installation.
+    # ? AUR packages are unsigned, user-submitted content, there is no PGP/signature verification
+    # ? available for a PKGBUILD, unlike official repository packages. Bootstrapping the AUR helper
+    # ? itself cannot go through an AUR helper's own review/verification options, since none is
+    # ? installed yet. Only the HTTPS transport to aur.archlinux.org is verified here.
     log_info "Installing $aur_helper AUR helper..."
     git clone "$AUR_GIT_URL"
     cd "$AUR_DIRECTORY"
+    if [ ! -f PKGBUILD ]; then
+        log_error "PKGBUILD not found after cloning $AUR_DIRECTORY, aborting installation!"
+        exit 1
+    fi
     makepkg -si --noconfirm
     cd ..
     rm -rf "$AUR_DIRECTORY"


### PR DESCRIPTION
**What**
Adds the explanatory comment `AGENTS.md` calls for on any security-relevant tradeoff, documenting that the AUR helper (`paru`/`yay`) is bootstrapped by cloning and building an unsigned, user-submitted `PKGBUILD` with no PGP/signature verification available, since no AUR helper exists yet to provide one. Also adds a sanity check that aborts if `PKGBUILD` is missing after the clone, instead of silently proceeding to `makepkg`.

**Why**
This is a real, accepted characteristic of the AUR (unsigned, user-submitted packages), not something fixable with the tooling available at the point the AUR helper itself is being installed, so it needed the documentation `AGENTS.md` requires rather than an invented verification step. The missing-`PKGBUILD` guard is a real, low-cost safety net for a truncated or failed clone, verified against both a clone missing `PKGBUILD` (aborts correctly) and a real clone of `paru`'s AUR repo (proceeds correctly).