### PR TITLE
Batch `install_packages` package-manager queries

### DIFF
--- a/scripts/helpers/functions/packages.sh
+++ b/scripts/helpers/functions/packages.sh
@@ -9,6 +9,20 @@ source "$PACKAGES_SCRIPT_DIRECTORY/strings.sh"
 
 # ? Importing constants.sh is not needed, because it is already sourced in the logs script.
 
+# Function to populate an associative array (passed by name) with every package
+# currently installed via the given package manager, queried once.
+# populate_installed_packages_set "package_manager" "array_name"
+populate_installed_packages_set() {
+    local package_manager="$1"
+    local -n installed_packages_set_ref="$2"
+
+    local installed_package
+    while IFS= read -r installed_package; do
+        # shellcheck disable=SC2034 # Reason: nameref, written into the caller's array by name, not read here.
+        installed_packages_set_ref["$installed_package"]=1
+    done < <("$package_manager" -Qq)
+}
+
 # Function to check if all packages are installed.
 # The file should contain one package per line.
 # The variable should contain packages separated by spaces.
@@ -26,10 +40,7 @@ are_packages_installed() {
     if [ -n "$package_manager" ]; then
         case "$package_manager" in
         "$AUR_PACKAGE_MANAGER" | "$ARCH_PACKAGE_MANAGER")
-            local installed_package
-            while IFS= read -r installed_package; do
-                installed_packages_set["$installed_package"]=1
-            done < <("$package_manager" -Qq)
+            populate_installed_packages_set "$package_manager" installed_packages_set
             ;;
         *)
             log_error "Unsupported package manager: '$package_manager'"
@@ -75,12 +86,13 @@ are_packages_installed() {
 }
 
 # Function to install a package if it is not already installed.
-# process_package "package" "install_command" "message"
+# process_package "package" "install_command" "message" "installed_packages_set_array_name"
 process_package() {
     local package
     package=$(trim_string "$1")
     local install_command="$2"
     local message="${3:-"Installing '$package' package..."}"
+    local -n installed_set_ref="$4"
 
     # Skip if it's a comment or empty.
     [[ "$package" == \#* ]] || [[ -z "$package" ]] && return
@@ -97,8 +109,7 @@ process_package() {
     fi
 
     # Install package if it is not already installed.
-    is_package_installed=$(are_packages_installed "$package" "$manager")
-    if [ "$is_package_installed" = "false" ]; then
+    if [[ -z "${installed_set_ref[$package]+x}" ]]; then
 
         # Print message.
         log_info "$message"
@@ -133,15 +144,19 @@ install_packages() {
         ;;
     esac
 
+    # List installed packages once for this whole batch instead of once per package below.
+    local -A installed_packages_set=()
+    populate_installed_packages_set "$manager" installed_packages_set
+
     # Determine if the input is a file or variable and act accordingly.
     if [[ -r "$input" ]]; then
         while IFS= read -r package; do
-            process_package "$package" "$install_command" "$message"
+            process_package "$package" "$install_command" "$message" installed_packages_set
         done <"$input"
     else
         IFS=' ' read -ra packages_array <<<"$input"
         for package in "${packages_array[@]}"; do
-            process_package "$package" "$install_command" "$message"
+            process_package "$package" "$install_command" "$message" installed_packages_set
         done
     fi
 }

--- a/test/packages.bats
+++ b/test/packages.bats
@@ -18,6 +18,9 @@ EOF
     chmod +x "$fake_bin/fakepacman"
     PATH="$fake_bin:$PATH"
 
+    sudo() { command "$@"; }
+    export -f sudo
+
     source "$BATS_TEST_DIRNAME/../scripts/helpers/functions/logs.sh"
     source "$BATS_TEST_DIRNAME/../scripts/helpers/functions/strings.sh"
     source "$packages_under_test"
@@ -47,4 +50,17 @@ EOF
 
     [ "$output" = "true" ]
     [ ! -s "$calls_log" ]
+}
+
+@test "install_packages lists installed packages once and installs only the missing, applying --nocheck only to !-prefixed packages" {
+    ARCH_PACKAGE_MANAGER="fakepacman"
+    printf 'bash\nwget\n!vim\n# comment\n\n' >"$BATS_TEST_TMPDIR/packages.txt"
+
+    install_packages "$BATS_TEST_TMPDIR/packages.txt" "fakepacman" "Installing..."
+
+    [ "$(grep -c '^call: -Qq$' "$calls_log")" -eq 1 ]
+    [ "$(grep -c '^call: -S' "$calls_log")" -eq 2 ]
+    grep -qxF 'call: -S --noconfirm --needed wget' "$calls_log"
+    grep -qxF 'call: -S --noconfirm --needed --mflags --nocheck vim' "$calls_log"
+    ! grep -q -- '-S.*bash' "$calls_log"
 }


### PR DESCRIPTION
**What**
`install_packages`/`process_package` called `are_packages_installed` once per package, which after the earlier batching fix in `are_packages_installed` means every single-package check now lists the *entire* set of installed packages (a `pacman -Qq` with no target prints every installed package, not just one), instead of the fast targeted `pacman -Qq <package>` lookup it used before. For an N-package install file, that was N full listings instead of N fast targeted queries.

Extracts the installed-package listing into a shared `populate_installed_packages_set` helper (used by both `are_packages_installed` and `install_packages`), and has `install_packages` build the set once per call and pass it to `process_package` by reference, so a whole package file now costs exactly one `pacman -Qq` regardless of size. This also removes `process_package`'s implicit reliance on `install_packages`''s local `$manager` variable via bash's dynamic scoping, since it no longer calls `are_packages_installed` itself.

**Why**
Verified with a fake `pacman` mock (1 listing call total, installs called only for genuinely missing packages, `--nocheck` applied only to `!`-prefixed entries) and against real `pacman` on a fresh Arch Linux container (correctly skips an already-installed package, installs a missing one).