### PR TITLE
Add unit test coverage for shared helper functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,15 @@ jobs:
       - name: Run bash -n on scripts
         run: find scripts -name '*.sh' -type f -exec bash -n {} \; && bash -n install.sh
 
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install bats
+        run: sudo apt-get update && sudo apt-get install -y bats
+      - name: Run unit tests
+        run: bats tests/unit
+
   gitleaks:
     runs-on: ubuntu-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,23 @@ series adds, and what remains. Read it before picking up work.
 - Every helper is idempotent through `compare_files` or `are_packages_installed`, safe to run
   more than once, a second run should report no changes and skip service restarts.
 
+## Automated tests
+
+- `tests/unit/` holds `bats` tests for `scripts/helpers/functions/*.sh`, the only layer that can
+  be exercised without a real Arch host: `tests/unit/test_helper/common.bash` provides
+  `setup_mock_bin` and `create_mock` to stub `sudo`, `pacman`, `systemctl`, and similar commands
+  on `PATH`, so tests never touch the real system.
+- Run the whole suite with `bats tests/unit`, or a single file with `bats tests/unit/state.bats`.
+- macOS ships bash 3.2 and BSD `sed`, both too old for some of the functions under test and for
+  `bats` itself. Put a newer `bash` (`brew install bash`) and GNU `sed` (`brew install gnu-sed`,
+  installed as `gsed`) ahead of the system ones on `PATH` before running the suite locally:
+  `PATH="/opt/homebrew/bin:/opt/homebrew/opt/gnu-sed/libexec/gnubin:$PATH" bats tests/unit`.
+  CI runs on `ubuntu-latest`, where the default `bash` and `sed` are already the GNU ones this
+  toolkit targets.
+- These tests cover pure function logic only. Behavior that depends on a real Arch userland,
+  actual package installs, `systemd` under a live PID 1, is exercised by the Docker-based
+  integration harness instead, see `documents/roadmap.md`.
+
 ## Shared helper functions
 
 Source `scripts/helpers/functions/*.sh` for these instead of writing a new equivalent:
@@ -112,6 +129,7 @@ find scripts -name '*.sh' -type f -exec bash -n {} \;
 bash -n install.sh
 markdownlint README.md --config .markdownlint.json
 grep -rn "keyboard\|kloak" scripts/ || true
+bats tests/unit
 ```
 
 ## Security

--- a/tests/unit/filesystem.bats
+++ b/tests/unit/filesystem.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+
+load test_helper/common
+
+setup() {
+    setup_mock_bin
+    # shellcheck disable=SC1091
+    source "$FUNCTIONS_DIRECTORY/filesystem.sh"
+}
+
+@test "compare_files reports false when the target file does not exist" {
+    run compare_files "$BATS_TEST_TMPDIR/missing" "$BATS_TEST_TMPDIR/missing-source"
+    [ "$output" = "false" ]
+}
+
+@test "compare_files reports true when target and source are identical" {
+    echo "same" >"$BATS_TEST_TMPDIR/source"
+    echo "same" >"$BATS_TEST_TMPDIR/target"
+    run compare_files "$BATS_TEST_TMPDIR/target" "$BATS_TEST_TMPDIR/source"
+    [ "$output" = "true" ]
+}
+
+@test "compare_files reports false when target and source differ" {
+    echo "one" >"$BATS_TEST_TMPDIR/source"
+    echo "two" >"$BATS_TEST_TMPDIR/target"
+    run compare_files "$BATS_TEST_TMPDIR/target" "$BATS_TEST_TMPDIR/source"
+    [ "$output" = "false" ]
+}
+
+@test "directory_exists_in_list finds a directory present in the list" {
+    excluded=("/sys" "/proc" "/boot")
+    run directory_exists_in_list "/proc" excluded
+    [ "$output" = "true" ]
+}
+
+@test "directory_exists_in_list reports false for a directory not in the list" {
+    excluded=("/sys" "/proc" "/boot")
+    run directory_exists_in_list "/etc" excluded
+    [ "$output" = "false" ]
+}
+
+@test "is_file_contained_in_another reports true when every line is present" {
+    printf 'a\nb\nc\n' >"$BATS_TEST_TMPDIR/container"
+    printf 'a\nb\n' >"$BATS_TEST_TMPDIR/subset"
+    run is_file_contained_in_another "$BATS_TEST_TMPDIR/container" "$BATS_TEST_TMPDIR/subset"
+    [ "$output" = "true" ]
+}
+
+@test "is_file_contained_in_another reports false when a line is missing" {
+    printf 'a\nb\n' >"$BATS_TEST_TMPDIR/container"
+    printf 'a\nc\n' >"$BATS_TEST_TMPDIR/other"
+    run is_file_contained_in_another "$BATS_TEST_TMPDIR/container" "$BATS_TEST_TMPDIR/other"
+    [ "$output" = "false" ]
+}
+
+@test "is_file_contained_in_another reports false when either file is empty" {
+    : >"$BATS_TEST_TMPDIR/empty"
+    printf 'a\n' >"$BATS_TEST_TMPDIR/other"
+    run is_file_contained_in_another "$BATS_TEST_TMPDIR/empty" "$BATS_TEST_TMPDIR/other"
+    [ "$output" = "false" ]
+}
+
+@test "change_configuration appends a new key that is not present yet" {
+    : >"$BATS_TEST_TMPDIR/config"
+    change_configuration "Port" " 2222" "$BATS_TEST_TMPDIR/config"
+    grep -qxF "Port 2222" "$BATS_TEST_TMPDIR/config"
+}
+
+@test "change_configuration replaces an existing uncommented key" {
+    printf 'Port 22\n' >"$BATS_TEST_TMPDIR/config"
+    change_configuration "Port" " 2222" "$BATS_TEST_TMPDIR/config"
+    [ "$(grep -c '^Port' "$BATS_TEST_TMPDIR/config")" -eq 1 ]
+    grep -qxF "Port 2222" "$BATS_TEST_TMPDIR/config"
+}
+
+@test "change_configuration replaces a commented-out key in place" {
+    printf '#Port 22\n' >"$BATS_TEST_TMPDIR/config"
+    change_configuration "Port" " 2222" "$BATS_TEST_TMPDIR/config"
+    grep -qxF "Port 2222" "$BATS_TEST_TMPDIR/config"
+}
+
+@test "append_line_to_file adds a missing line and reports true" {
+    : >"$BATS_TEST_TMPDIR/config"
+    run append_line_to_file "$BATS_TEST_TMPDIR/config" "new line" ""
+    [[ "$output" == *"true"* ]]
+    grep -qxF "new line" "$BATS_TEST_TMPDIR/config"
+}
+
+@test "append_line_to_file reports false when the line already exists" {
+    printf 'existing line\n' >"$BATS_TEST_TMPDIR/config"
+    run append_line_to_file "$BATS_TEST_TMPDIR/config" "existing line" ""
+    [[ "$output" == *"false"* ]]
+    [ "$(grep -c '^existing line$' "$BATS_TEST_TMPDIR/config")" -eq 1 ]
+}

--- a/tests/unit/logs.bats
+++ b/tests/unit/logs.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+
+load test_helper/common
+
+setup() {
+    # shellcheck disable=SC1091
+    source "$FUNCTIONS_DIRECTORY/logs.sh"
+}
+
+@test "log_info prints the message with a leading blank line by default" {
+    run log_info "hello"
+    [ "$status" -eq 0 ]
+    stripped="$(strip_ansi "$output")"
+    [ "$stripped" = $'\nhello' ]
+}
+
+@test "log_info -n prints the message without a leading blank line" {
+    run log_info -n "hello"
+    [ "$status" -eq 0 ]
+    stripped="$(strip_ansi "$output")"
+    [ "$stripped" = "hello" ]
+}
+
+@test "log_success prints the given message" {
+    run log_success -n "done"
+    [ "$status" -eq 0 ]
+    stripped="$(strip_ansi "$output")"
+    [ "$stripped" = "done" ]
+}
+
+@test "log_warning prints the given message" {
+    run log_warning -n "careful"
+    [ "$status" -eq 0 ]
+    stripped="$(strip_ansi "$output")"
+    [ "$stripped" = "careful" ]
+}
+
+@test "log_error prints the given message" {
+    run log_error -n "broken"
+    [ "$status" -eq 0 ]
+    stripped="$(strip_ansi "$output")"
+    [ "$stripped" = "broken" ]
+}

--- a/tests/unit/packages.bats
+++ b/tests/unit/packages.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+
+load test_helper/common
+
+# process_package is only ever invoked from within install_packages, and
+# relies on that caller's local "manager" variable via bash dynamic scoping
+# (it is not one of process_package's own parameters). Tests below drive it
+# through install_packages, its only real call path, rather than calling it
+# directly with different assumptions.
+
+setup() {
+    setup_mock_bin
+    MOCK_STATE_DIRECTORY="$BATS_TEST_TMPDIR/pacman-state"
+    CALL_LOG="$BATS_TEST_TMPDIR/pacman-calls.log"
+    mkdir -p "$MOCK_STATE_DIRECTORY"
+    : >"$CALL_LOG"
+    create_mock pacman '
+state_directory="'"$MOCK_STATE_DIRECTORY"'"
+echo "$*" >>"'"$CALL_LOG"'"
+case "$1" in
+-Qq)
+    [ -f "$state_directory/installed-$2" ] && exit 0 || exit 1
+    ;;
+-S)
+    shift
+    for arg in "$@"; do
+        case "$arg" in
+        --noconfirm | --needed | --mflags | --nocheck) ;;
+        *) touch "$state_directory/installed-$arg" ;;
+        esac
+    done
+    ;;
+esac
+'
+    # shellcheck disable=SC1091
+    source "$FUNCTIONS_DIRECTORY/packages.sh"
+}
+
+@test "are_packages_installed reports true when every package is installed" {
+    touch "$MOCK_STATE_DIRECTORY/installed-git"
+    touch "$MOCK_STATE_DIRECTORY/installed-curl"
+    run are_packages_installed "git curl" "pacman"
+    [ "$output" = "true" ]
+}
+
+@test "are_packages_installed reports false when a package is missing" {
+    touch "$MOCK_STATE_DIRECTORY/installed-git"
+    run are_packages_installed "git curl" "pacman"
+    [ "$output" = "false" ]
+}
+
+@test "are_packages_installed reads packages from a file, skipping comments and blanks" {
+    touch "$MOCK_STATE_DIRECTORY/installed-git"
+    printf '# comment\n\ngit\n' >"$BATS_TEST_TMPDIR/packages.txt"
+    run are_packages_installed "$BATS_TEST_TMPDIR/packages.txt" "pacman"
+    [ "$output" = "true" ]
+}
+
+@test "are_packages_installed rejects an unsupported package manager" {
+    run are_packages_installed "git" "some-other-manager"
+    [ "$status" -eq 1 ]
+}
+
+@test "install_packages installs every package listed in a file" {
+    printf 'git\ncurl\n' >"$BATS_TEST_TMPDIR/packages.txt"
+    install_packages "$BATS_TEST_TMPDIR/packages.txt" "pacman"
+    [ -f "$MOCK_STATE_DIRECTORY/installed-git" ]
+    [ -f "$MOCK_STATE_DIRECTORY/installed-curl" ]
+}
+
+@test "install_packages installs every package listed in a space separated string" {
+    install_packages "git curl" "pacman"
+    [ -f "$MOCK_STATE_DIRECTORY/installed-git" ]
+    [ -f "$MOCK_STATE_DIRECTORY/installed-curl" ]
+}
+
+@test "install_packages skips a package that is already installed" {
+    touch "$MOCK_STATE_DIRECTORY/installed-git"
+    install_packages "git" "pacman"
+    ! grep -q -- '^-S ' "$CALL_LOG"
+}
+
+@test "install_packages skips comment and blank lines in a package file" {
+    printf '# comment\n\ngit\n' >"$BATS_TEST_TMPDIR/packages.txt"
+    install_packages "$BATS_TEST_TMPDIR/packages.txt" "pacman"
+    [ -f "$MOCK_STATE_DIRECTORY/installed-git" ]
+    [ "$(grep -c -- '^-S ' "$CALL_LOG")" -eq 1 ]
+}
+
+@test "install_packages strips a leading '!' and disables package tests" {
+    install_packages "!git" "pacman"
+    [ -f "$MOCK_STATE_DIRECTORY/installed-git" ]
+    grep -qxF -- '-S --noconfirm --needed --mflags --nocheck git' "$CALL_LOG"
+}
+
+@test "install_packages rejects an unsupported package manager" {
+    run install_packages "git" "some-other-manager"
+    [ "$status" -eq 1 ]
+}

--- a/tests/unit/services.bats
+++ b/tests/unit/services.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+
+load test_helper/common
+
+setup() {
+    setup_mock_bin
+    MOCK_STATE_DIRECTORY="$BATS_TEST_TMPDIR/systemctl-state"
+    CALL_LOG="$BATS_TEST_TMPDIR/systemctl-calls.log"
+    mkdir -p "$MOCK_STATE_DIRECTORY"
+    : >"$CALL_LOG"
+    create_mock systemctl '
+state_directory="'"$MOCK_STATE_DIRECTORY"'"
+echo "$*" >>"'"$CALL_LOG"'"
+action="$1"
+shift
+service=""
+for arg in "$@"; do
+    case "$arg" in
+    --*) ;;
+    *) service="$arg" ;;
+    esac
+done
+case "$action" in
+is-active) [ -f "$state_directory/active-$service" ] && exit 0 || exit 1 ;;
+is-enabled) [ -f "$state_directory/enabled-$service" ] && exit 0 || exit 1 ;;
+enable) touch "$state_directory/enabled-$service" ;;
+start) touch "$state_directory/active-$service" ;;
+stop) rm -f "$state_directory/active-$service" ;;
+esac
+'
+    # shellcheck disable=SC1091
+    source "$FUNCTIONS_DIRECTORY/services.sh"
+}
+
+@test "is_service_active reports false for a service that was never started" {
+    run is_service_active "example.service"
+    [ "$output" = "false" ]
+}
+
+@test "is_service_active reports true once the service is marked active" {
+    touch "$MOCK_STATE_DIRECTORY/active-example.service"
+    run is_service_active "example.service"
+    [ "$output" = "true" ]
+}
+
+@test "is_service_enabled reports true once the service is marked enabled" {
+    touch "$MOCK_STATE_DIRECTORY/enabled-example.service"
+    run is_service_enabled "example.service"
+    [ "$output" = "true" ]
+}
+
+@test "enable_service enables a service that is not enabled yet" {
+    enable_service "example.service" "" >/dev/null
+    [ -f "$MOCK_STATE_DIRECTORY/enabled-example.service" ]
+    grep -q '^enable example.service$' "$CALL_LOG"
+}
+
+@test "enable_service is a no-op when the service is already enabled" {
+    touch "$MOCK_STATE_DIRECTORY/enabled-example.service"
+    enable_service "example.service" "" >/dev/null
+    ! grep -q '^enable ' "$CALL_LOG"
+}
+
+@test "start_service starts a service that is not active yet" {
+    start_service "example.service" "" >/dev/null
+    [ -f "$MOCK_STATE_DIRECTORY/active-example.service" ]
+    grep -q '^start example.service$' "$CALL_LOG"
+}
+
+@test "start_service is a no-op when the service is already active" {
+    touch "$MOCK_STATE_DIRECTORY/active-example.service"
+    start_service "example.service" "" >/dev/null
+    ! grep -q '^start ' "$CALL_LOG"
+}
+
+@test "stop_service stops a service that is currently active" {
+    touch "$MOCK_STATE_DIRECTORY/active-example.service"
+    stop_service "example.service" "" >/dev/null
+    [ ! -f "$MOCK_STATE_DIRECTORY/active-example.service" ]
+    grep -q '^stop example.service$' "$CALL_LOG"
+}
+
+@test "stop_service is a no-op when the service is already inactive" {
+    stop_service "example.service" "" >/dev/null
+    ! grep -q '^stop ' "$CALL_LOG"
+}
+
+@test "services default to system mode, not user mode" {
+    run is_service_active "example.service"
+    [ "$status" -eq 0 ]
+    [ "$output" = "false" ]
+    ! grep -q -- '--user' "$CALL_LOG"
+}

--- a/tests/unit/state.bats
+++ b/tests/unit/state.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+
+load test_helper/common
+
+setup() {
+    setup_mock_bin
+    export ARCH_TUNER_STATE_DIRECTORY="$BATS_TEST_TMPDIR/state"
+    # shellcheck disable=SC1091
+    source "$FUNCTIONS_DIRECTORY/state.sh"
+}
+
+@test "change_flag_value writes a numeric value unquoted" {
+    change_flag_value "SOME_FLAG" 1
+    grep -qxF 'SOME_FLAG=1' "$STATE_FILE"
+}
+
+@test "change_flag_value writes a non-numeric value quoted" {
+    change_flag_value "SOME_FLAG" "server"
+    grep -qxF 'SOME_FLAG="server"' "$STATE_FILE"
+}
+
+@test "change_flag_value replaces a previous value for the same flag" {
+    change_flag_value "SOME_FLAG" 0
+    change_flag_value "SOME_FLAG" 1
+    [ "$(grep -c '^SOME_FLAG=' "$STATE_FILE")" -eq 1 ]
+    grep -qxF 'SOME_FLAG=1' "$STATE_FILE"
+}
+
+@test "change_flag_value preserves other flags already in the state file" {
+    change_flag_value "FIRST_FLAG" 1
+    change_flag_value "SECOND_FLAG" "value"
+    grep -qxF 'FIRST_FLAG=1' "$STATE_FILE"
+    grep -qxF 'SECOND_FLAG="value"' "$STATE_FILE"
+}
+
+@test "change_flag_value rejects a value containing a double quote" {
+    run change_flag_value "SOME_FLAG" 'bad"value'
+    [ "$status" -eq 1 ]
+    [ ! -f "$STATE_FILE" ]
+}
+
+@test "change_flag_value rejects a value containing a backslash" {
+    run change_flag_value "SOME_FLAG" 'bad\value'
+    [ "$status" -eq 1 ]
+}
+
+@test "change_flag_value rejects a value containing a newline" {
+    run change_flag_value "SOME_FLAG" "$(printf 'bad\nvalue')"
+    [ "$status" -eq 1 ]
+}
+
+@test "source_state loads flags from an existing state file" {
+    change_flag_value "SOURCED_FLAG" 1
+    unset SOURCED_FLAG
+    source_state
+    [ "$SOURCED_FLAG" -eq 1 ]
+}
+
+@test "source_state is a no-op when no state file exists" {
+    run source_state
+    [ "$status" -eq 0 ]
+}
+
+@test "reset_state removes an existing state file" {
+    change_flag_value "SOME_FLAG" 1
+    [ -f "$STATE_FILE" ]
+    reset_state
+    [ ! -f "$STATE_FILE" ]
+}
+
+@test "reset_state is a no-op when no state file exists" {
+    run reset_state
+    [ "$status" -eq 0 ]
+}

--- a/tests/unit/strings.bats
+++ b/tests/unit/strings.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+
+load test_helper/common
+
+setup() {
+    # shellcheck disable=SC1091
+    source "$FUNCTIONS_DIRECTORY/strings.sh"
+}
+
+@test "trim_string removes leading and trailing whitespace" {
+    run trim_string "   padded value   "
+    [ "$status" -eq 0 ]
+    [ "$output" = "padded value" ]
+}
+
+@test "trim_string leaves internal whitespace untouched" {
+    run trim_string "  one two  "
+    [ "$status" -eq 0 ]
+    [ "$output" = "one two" ]
+}
+
+@test "trim_string returns an already-trimmed string unchanged" {
+    run trim_string "clean"
+    [ "$status" -eq 0 ]
+    [ "$output" = "clean" ]
+}

--- a/tests/unit/system.bats
+++ b/tests/unit/system.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+
+load test_helper/common
+
+# Only the process-management functions are unit tested here. update_system
+# and reset_system_to_clean_state drive real pacman/chsh/reboot behavior and
+# are exercised in the Docker integration harness instead.
+
+setup() {
+    setup_mock_bin
+    export ARCH_TUNER_STATE_DIRECTORY="$BATS_TEST_TMPDIR/state"
+    # shellcheck disable=SC1091
+    source "$FUNCTIONS_DIRECTORY/system.sh"
+}
+
+@test "is_process_running reports false when no matching process exists" {
+    run is_process_running "arch-tuner-nonexistent-process-marker"
+    [ "$output" = "false" ]
+}
+
+@test "is_process_running reports true while a matching process is alive" {
+    bash -c 'exec -a arch-tuner-test-proc-alive sleep 5' &
+    local pid=$!
+    sleep 0.2
+    run is_process_running "arch-tuner-test-proc-alive"
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    [ "$output" = "true" ]
+}
+
+@test "stop_process terminates a matching running process" {
+    bash -c 'exec -a arch-tuner-test-proc-stop sleep 30' &
+    local pid=$!
+    sleep 0.2
+    stop_process "arch-tuner-test-proc-stop" "" >/dev/null
+    sleep 0.2
+    run is_process_running "arch-tuner-test-proc-stop"
+    [ "$output" = "false" ]
+}
+
+@test "stop_process is a no-op when no matching process exists" {
+    run stop_process "arch-tuner-nonexistent-process-marker" ""
+    [ "$status" -eq 0 ]
+}
+
+@test "reboot_system does nothing when the flag is already 0" {
+    run reboot_system 0 "SOME_FLAG"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}

--- a/tests/unit/test_helper/common.bash
+++ b/tests/unit/test_helper/common.bash
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Shared bats helpers: locate the functions library under test and provide
+# PATH-scoped mock executables so tests never touch a real system.
+
+REPOSITORY_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+# shellcheck disable=SC2034 # Reason: consumed by the bats files that load this helper.
+FUNCTIONS_DIRECTORY="$REPOSITORY_ROOT/scripts/helpers/functions"
+
+# Creates an isolated directory on PATH for mock executables and a permissive
+# sudo mock that just runs the real command, since tests never touch real
+# system paths.
+# Usage:
+#   setup_mock_bin
+setup_mock_bin() {
+    MOCK_BIN_DIRECTORY="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$MOCK_BIN_DIRECTORY"
+    PATH="$MOCK_BIN_DIRECTORY:$PATH"
+    create_mock sudo 'exec "$@"'
+}
+
+# Writes an executable mock command to the mock bin directory.
+# Usage:
+#   create_mock "command_name" 'shell body'
+create_mock() {
+    local name="$1"
+    local body="$2"
+    cat >"$MOCK_BIN_DIRECTORY/$name" <<SCRIPT
+#!/usr/bin/env bash
+$body
+SCRIPT
+    chmod +x "$MOCK_BIN_DIRECTORY/$name"
+}
+
+# Strips ANSI color escape codes from a string, since log_* functions color
+# their output and tests should assert on message content, not styling.
+# Usage:
+#   strip_ansi "$output"
+strip_ansi() {
+    printf '%s' "$1" | sed -E $'s/\x1b\\[[0-9;]*m//g'
+}

--- a/tests/unit/ui.bats
+++ b/tests/unit/ui.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+
+load test_helper/common
+
+setup() {
+    # shellcheck disable=SC1091
+    source "$FUNCTIONS_DIRECTORY/ui.sh"
+}
+
+@test "prompt_user_input returns the typed value" {
+    result=$(prompt_user_input "prompt" "default" <<<"typed" 2>/dev/null)
+    [ "$result" = "typed" ]
+}
+
+@test "prompt_user_input falls back to the default value when input is empty" {
+    result=$(prompt_user_input "prompt" "default" <<<"" 2>/dev/null)
+    [ "$result" = "default" ]
+}
+
+@test "choose_option returns the option selected by number" {
+    result=$(choose_option "prompt" "alpha" "beta" "gamma" <<<"2" 2>/dev/null)
+    [ "$result" = "beta" ]
+}
+
+@test "choose_option defaults to the first option when input is empty" {
+    result=$(choose_option "prompt" "alpha" "beta" <<<"" 2>/dev/null)
+    [ "$result" = "alpha" ]
+}
+
+@test "ask_user_before_execution returns n without executing anything when declined" {
+    marker="$BATS_TEST_TMPDIR/marker"
+    result=$(ask_user_before_execution "Proceed?" "true" "touch $marker" <<<"n" 2>/dev/null)
+    [ "$result" = "n" ]
+    [ ! -f "$marker" ]
+}
+
+@test "ask_user_before_execution executes a plain command when approved" {
+    marker="$BATS_TEST_TMPDIR/marker"
+    result=$(ask_user_before_execution "Proceed?" "true" "touch $marker" <<<"y" 2>/dev/null)
+    [ "$result" = "y" ]
+    [ -f "$marker" ]
+}
+
+@test "ask_user_before_execution invokes a named function via the script#function syntax" {
+    marker="$BATS_TEST_TMPDIR/marker"
+    cat >"$BATS_TEST_TMPDIR/helper.sh" <<SCRIPT
+mark_called() {
+    touch "$marker"
+}
+SCRIPT
+    result=$(ask_user_before_execution "Proceed?" "true" "$BATS_TEST_TMPDIR/helper.sh#mark_called" <<<"y" 2>/dev/null)
+    [ "$result" = "y" ]
+    [ -f "$marker" ]
+}
+
+@test "ask_user_before_execution executes an existing script file directly" {
+    marker="$BATS_TEST_TMPDIR/marker"
+    cat >"$BATS_TEST_TMPDIR/script.sh" <<SCRIPT
+#!/bin/sh
+touch "$marker"
+SCRIPT
+    chmod +x "$BATS_TEST_TMPDIR/script.sh"
+    result=$(ask_user_before_execution "Proceed?" "true" "$BATS_TEST_TMPDIR/script.sh" <<<"y" 2>/dev/null)
+    [ "$result" = "y" ]
+    [ -f "$marker" ]
+}


### PR DESCRIPTION
**What**:

1. **Test harness**: Add `bats` tests under `tests/unit/` for `scripts/helpers/functions/*.sh`, with `tests/unit/test_helper/common.bash` providing PATH-scoped mocks for `sudo`, `pacman`, and `systemctl` so tests never touch a real system.
2. **Documentation**: Document how to run the suite, and the macOS-vs-Linux `bash`/`sed` version caveat, in `AGENTS.md`.
3. **CI**: Run the suite in a new `unit-tests` job in `.github/workflows/ci.yml`.

**Why**:

The only verification this toolkit had was `shellcheck` and `bash -n`, no script had ever actually been run and asserted against. This is the first of a series of pull requests working through `documents/roadmap.md`'s remaining and backlog items, plus a few security findings, and every later change in that series should be checkable against a real test run instead of syntax checking alone.