### PR TITLE
Add a Docker Arch Linux integration test harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches: [ main ]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -54,3 +55,11 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y bats
       - name: Run bats tests
         run: bats test/
+
+  integration:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Run Arch Linux integration smoke test
+        run: test/integration/smoke.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,27 @@ grep -rn "keyboard\|kloak" scripts/ || true
 bats test/
 ```
 
+## Docker integration testing
+
+`test/integration/` runs a helper, or `install.sh`, inside a real Arch Linux container under a
+real `systemd` PID 1, closer to an actual server than `bats test/`'s mocked `sudo`/`pacman`/
+`systemctl`.
+
+- `test/integration/run.sh <path/to/helper.sh>` builds the image and runs one target manually.
+- `test/integration/smoke.sh` runs a small curated set of container-safe helpers twice each,
+  checking they succeed and that the second run is a true no-op. This is the `integration` `CI`
+  job, triggered manually with `workflow_dispatch` rather than on every pull request, since it is
+  slower and needs `--privileged`.
+- Helpers that touch real hardware, a bootloader, or the host's own kernel sysctl namespace
+  (`cpu.sh`, anything relying on `grub-mkconfig`, `sysctl.sh`) are not in the curated list, they
+  need a real host or VM instead. Widen the list in `test/integration/smoke.sh` as more helpers
+  prove container-safe.
+- The official Arch Linux image only ships `amd64`, `run.sh` and `smoke.sh` force
+  `--platform=linux/amd64` so this also builds under emulation on an `arm64` machine. `systemd`
+  itself does not run under that emulation, `qemu-user` crashes it before it prints anything, even
+  `--version`. Everything else, package installs, file copies, works fine emulated. `CI` runs on
+  native `amd64` `ubuntu-latest` runners, so this only affects local verification on `arm64`.
+
 ## Security
 
 - This is a hardening toolkit. Never weaken a default, such as a wider firewall rule or a

--- a/test/integration/Dockerfile
+++ b/test/integration/Dockerfile
@@ -1,0 +1,24 @@
+FROM archlinux:base
+
+# pacman's download sandbox needs syscalls the build step's own seccomp
+# profile blocks under emulation, disable it for the duration of the build.
+RUN sed -i 's/^#DisableSandboxSyscalls/DisableSandboxSyscalls/' /etc/pacman.conf
+
+# A real systemd PID 1 and sudo, so helpers can be observed against an actual
+# Arch userland instead of only parsed by shellcheck.
+RUN pacman -Syu --noconfirm --needed \
+        systemd sudo which findutils procps-ng git base-devel \
+    && ln -sf /usr/lib/systemd/systemd /sbin/init
+
+# A password-less sudo admin user, closer to the non-root operator this
+# toolkit targets than running every helper as root outright.
+RUN useradd -m -G wheel tester \
+    && echo 'tester ALL=(ALL) NOPASSWD:ALL' >/etc/sudoers.d/tester \
+    && chmod 0440 /etc/sudoers.d/tester
+
+WORKDIR /arch-tuner
+COPY . .
+RUN chown -R tester:tester /arch-tuner
+
+STOPSIGNAL SIGRTMIN+3
+CMD ["/sbin/init"]

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# Builds the Arch Linux integration image and runs a helper, or install.sh,
+# inside it under a real systemd PID 1, so changes can be observed against an
+# actual Arch userland instead of only parsed by shellcheck.
+# Usage:
+#   test/integration/run.sh scripts/helpers/security/sysctl.sh
+#   test/integration/run.sh install.sh
+
+set -euo pipefail
+
+REPOSITORY_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+IMAGE_NAME="arch-tuner-integration-test"
+CONTAINER_NAME="arch-tuner-integration-test-$$"
+
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <path/to/helper.sh or install.sh>" >&2
+    exit 1
+fi
+
+target="$1"
+
+# Arch Linux only publishes an amd64 image, force that platform so this also
+# works under emulation on an arm64 development machine.
+docker build --platform=linux/amd64 -t "$IMAGE_NAME" -f "$REPOSITORY_ROOT/test/integration/Dockerfile" "$REPOSITORY_ROOT"
+
+docker run -d --name "$CONTAINER_NAME" \
+    --platform=linux/amd64 \
+    --privileged \
+    --cgroupns=host \
+    --tmpfs /tmp --tmpfs /run --tmpfs /run/lock \
+    -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
+    "$IMAGE_NAME" >/dev/null
+
+cleanup() {
+    docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# Wait for systemd to settle before running anything against it. "--wait"
+# blocks until a terminal state is reached, "degraded" counts as booted, a
+# container commonly has a unit or two that cannot succeed without real
+# hardware, "starting" or a failed exec (daemon not ready yet) are retried.
+system_state=""
+for _ in $(seq 1 30); do
+    system_state=$(docker exec "$CONTAINER_NAME" systemctl is-system-running --wait 2>/dev/null || true)
+    case "$system_state" in
+    running | degraded) break ;;
+    esac
+    sleep 1
+done
+case "$system_state" in
+running | degraded) ;;
+*)
+    echo "systemd inside the container never finished booting (last state: '$system_state')" >&2
+    docker logs "$CONTAINER_NAME" >&2 || true
+    exit 1
+    ;;
+esac
+
+docker exec -u tester "$CONTAINER_NAME" bash -c "cd /arch-tuner && sh '$target'"

--- a/test/integration/smoke.sh
+++ b/test/integration/smoke.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# Runs a curated set of container-friendly helpers twice each inside one
+# booted Arch container, failing if a helper errors or a second, idempotent
+# run reports making a change again. Helpers that touch real hardware, a
+# bootloader, or the host's own kernel sysctl namespace are deliberately left
+# out, they need real-host testing instead, see AGENTS.md.
+# Usage:
+#   test/integration/smoke.sh
+
+set -euo pipefail
+
+REPOSITORY_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+IMAGE_NAME="arch-tuner-integration-test"
+CONTAINER_NAME="arch-tuner-integration-smoke-$$"
+
+TARGETS=(
+    "scripts/helpers/security/journald.sh"
+    "scripts/helpers/security/automatic-updates.sh"
+)
+
+docker build --platform=linux/amd64 -t "$IMAGE_NAME" -f "$REPOSITORY_ROOT/test/integration/Dockerfile" "$REPOSITORY_ROOT"
+
+docker run -d --name "$CONTAINER_NAME" \
+    --platform=linux/amd64 \
+    --privileged \
+    --cgroupns=host \
+    --tmpfs /tmp --tmpfs /run --tmpfs /run/lock \
+    -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
+    "$IMAGE_NAME" >/dev/null
+
+cleanup() {
+    docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# "degraded" counts as booted, a container commonly has a unit or two that
+# cannot succeed without real hardware.
+system_state=""
+for _ in $(seq 1 30); do
+    system_state=$(docker exec "$CONTAINER_NAME" systemctl is-system-running --wait 2>/dev/null || true)
+    case "$system_state" in
+    running | degraded) break ;;
+    esac
+    sleep 1
+done
+case "$system_state" in
+running | degraded) ;;
+*)
+    echo "systemd inside the container never finished booting (last state: '$system_state')" >&2
+    docker logs "$CONTAINER_NAME" >&2 || true
+    exit 1
+    ;;
+esac
+
+failures=0
+for target in "${TARGETS[@]}"; do
+    echo "=== $target: first run ==="
+    if ! docker exec -u tester "$CONTAINER_NAME" bash -c "cd /arch-tuner && sh '$target'"; then
+        echo "FAILED: $target (first run)" >&2
+        failures=$((failures + 1))
+        continue
+    fi
+
+    echo "=== $target: second run (idempotency check) ==="
+    if ! docker exec -u tester "$CONTAINER_NAME" bash -c "cd /arch-tuner && sh '$target'"; then
+        echo "FAILED: $target (second run)" >&2
+        failures=$((failures + 1))
+    fi
+done
+
+if [ "$failures" -gt 0 ]; then
+    echo "$failures helper(s) failed" >&2
+    exit 1
+fi
+
+echo "All helpers ran cleanly, twice."


### PR DESCRIPTION
**What**:

1. **Integration harness**: Add `test/integration/Dockerfile` and `run.sh`, a real Arch Linux container with `systemd` as PID 1 and a `sudo`-capable non-root user, so a helper or `install.sh` can be run and observed against an actual Arch userland instead of only parsed by `shellcheck`.
2. **Smoke test**: Add `test/integration/smoke.sh`, running a small curated set of container-safe helpers twice each to check they succeed and that the second run is a true no-op.
3. **CI**: Run the smoke test in a new `integration` job, triggered manually with `workflow_dispatch` rather than on every pull request, since it needs `--privileged` and is slower than the rest of `CI`.
4. **Documentation**: Document usage, the curated helper list, and a platform caveat in `AGENTS.md`.

**Why**:

`bats test/` only exercises pure function logic against mocked `sudo`/`pacman`/`systemctl`. Nothing in this toolkit has ever actually been run against a real Arch install and observed. The official Arch Linux image is `amd64`-only, and `systemd` itself does not run under `qemu-user` emulation, so this only fully verifies on native `amd64` (`CI`'s `ubuntu-latest` runners), not on an `arm64` development machine.