### PR TITLE
Harden state.sh directory and file permissions

### DIFF
--- a/scripts/helpers/functions/state.sh
+++ b/scripts/helpers/functions/state.sh
@@ -18,12 +18,15 @@ change_flag_value() {
         return 1
     fi
 
-    # Ensure the state directory exists.
+    # Ensure the state directory exists and stays root-only, this file is
+    # sourced as executable bash on every run.
     mkdir -p "$STATE_DIRECTORY"
+    chmod 0700 "$STATE_DIRECTORY"
 
     # Write to a temporary file, then atomically replace the state file.
     local temp_file
     temp_file=$(mktemp "$STATE_DIRECTORY/.state.XXXXXX")
+    chmod 0600 "$temp_file"
 
     # Drop any existing line for this flag, then append the new value.
     grep -v -F -- "$flag=" "$STATE_FILE" 2>/dev/null > "$temp_file" || true

--- a/test/state.bats
+++ b/test/state.bats
@@ -30,3 +30,13 @@ setup() {
 
     ! grep -E 'change_flag_value "\$[A-Z_]+"' <<<"$function_body"
 }
+
+@test "change_flag_value keeps the state directory and file root-only" {
+    change_flag_value "EXAMPLE_FLAG" "1"
+
+    directory_permissions=$(stat -c '%a' "$STATE_DIRECTORY" 2>/dev/null || stat -f '%OLp' "$STATE_DIRECTORY")
+    [ "$directory_permissions" = "700" ]
+
+    file_permissions=$(stat -c '%a' "$STATE_FILE" 2>/dev/null || stat -f '%OLp' "$STATE_FILE")
+    [ "$file_permissions" = "600" ]
+}


### PR DESCRIPTION
**What**:

1. **Permissions**: `chmod 0700` the state directory and `0600` the temporary file `change_flag_value` writes, before it becomes `/var/lib/arch-tuner/state.sh`.
2. **Test**: Add a regression test in `test/state.bats` asserting both permissions after a write.

**Why**:

`source_state` runs this file as executable bash on every helper invocation. Before the essentials phase applies its own `umask` hardening, the directory could end up group/world-readable depending on the current process umask, worth being explicit rather than relying on that.