### PR TITLE
Adopt change_configuration in 8 flagged helpers

### DIFF
--- a/scripts/helpers/essentials/aur.sh
+++ b/scripts/helpers/essentials/aur.sh
@@ -12,6 +12,7 @@ AUR_SCRIPT_DIRECTORY=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # Import functions.
 source "$AUR_SCRIPT_DIRECTORY/../functions/packages.sh"
 source "$AUR_SCRIPT_DIRECTORY/../functions/ui.sh"
+source "$AUR_SCRIPT_DIRECTORY/../functions/filesystem.sh"
 
 # Check if an AUR helper is already installed.
     aur_helper=""
@@ -103,7 +104,7 @@ paru)
     if [ -f "$PARU_CONFIGURATION" ]; then
         if ! grep -qxF "CleanMethod = KeepInstalled" "$PARU_CONFIGURATION"; then
             log_info "Adding CleanMethod = KeepInstalled to $aur_helper configuration..."
-            echo "CleanMethod = KeepInstalled" | sudo tee -a "$PARU_CONFIGURATION" >/dev/null
+            change_configuration "CleanMethod" " = KeepInstalled" "$PARU_CONFIGURATION"
         else
             log_info "CleanMethod = KeepInstalled already configured."
         fi
@@ -124,10 +125,9 @@ paru)
 
         # Add each configuration option if not already present.
         for configuration_option in "${CONFIGURATION_OPTIONS[@]}"; do
-            # TODO: Try using the `change_configuration` function.
             if ! grep -qxF "$configuration_option" "$PARU_CONFIGURATION"; then
                 log_info "Adding '$configuration_option' to $AUR_PACKAGE_MANAGER configuration..."
-                echo "$configuration_option" | sudo tee -a "$PARU_CONFIGURATION" >/dev/null
+                change_configuration "$configuration_option" "" "$PARU_CONFIGURATION"
             fi
         done
     fi

--- a/scripts/helpers/essentials/pacman.sh
+++ b/scripts/helpers/essentials/pacman.sh
@@ -28,17 +28,15 @@ if ! append_line_to_file "$PACMAN_CONFIGURATION" "SigLevel = Required DatabaseOp
 fi
 
 # Enable colors in terminal.
-# TODO: Try using the `change_configuration` function.
-if ! grep -q '^Color' $PACMAN_CONFIGURATION; then
+if ! grep -q '^Color' "$PACMAN_CONFIGURATION"; then
     log_info "Enabling colors in terminal..."
-    sudo sed -i '/^#.*Color/s/^#//' $PACMAN_CONFIGURATION
+    change_configuration "Color" "" "$PACMAN_CONFIGURATION"
 fi
 
 # Enable parallel downloads.
-# TODO: Try using the `change_configuration` function.
-if ! grep -q '^ParallelDownloads' $PACMAN_CONFIGURATION; then
+if ! grep -q '^ParallelDownloads' "$PACMAN_CONFIGURATION"; then
     log_info "Enabling parallel downloads..."
-    sudo sed -i '/^#.*ParallelDownloads/s/^#//' $PACMAN_CONFIGURATION
+    change_configuration "ParallelDownloads" " = 5" "$PACMAN_CONFIGURATION"
 fi
 
 # Enable cache clearing after package installation.

--- a/scripts/helpers/essentials/shell.sh
+++ b/scripts/helpers/essentials/shell.sh
@@ -56,7 +56,10 @@ configure_fish_shell_files "$FISH_CONFIGURATION" "$FISH_FUNCTIONS_TO_PASS" "$FIS
 current_shell=$(basename "$SHELL")
 if [ "$current_shell" != "$FISH_SHELL" ]; then
     log_info "Setting default shell..."
-    # TODO: Try using the `change_configuration` function.
-    grep -qxF "$FISH_BINARY_DIRECTORY" /etc/shells || echo "$FISH_BINARY_DIRECTORY" | sudo tee -a /etc/shells >/dev/null
-    sudo chsh -s "$FISH_BINARY_DIRECTORY" $USER
+
+    # change_configuration does not apply here, /etc/shells is a plain list
+    # of paths, not key/value pairs, append_line_to_file already covers
+    # exact-line dedup and append.
+    append_line_to_file "/etc/shells" "$FISH_BINARY_DIRECTORY" "" >/dev/null
+    sudo chsh -s "$FISH_BINARY_DIRECTORY" "$USER"
 fi

--- a/scripts/helpers/functions/filesystem.sh
+++ b/scripts/helpers/functions/filesystem.sh
@@ -16,7 +16,9 @@ append_line_to_file() {
     local line_to_append="$2"
     local message="$3"
 
-    # TODO: Try using the `change_configuration` function.
+    # change_configuration does not apply here, it replaces a single key's
+    # value, this appends an exact, possibly key-less line and dedupes on the
+    # whole line instead.
     if ! grep -qxF "$line_to_append" "$file_path"; then
 
         # Print message if it exists.
@@ -201,7 +203,9 @@ configure_fish_shell_files() {
             mkdir -p "$target_directory"
             cp -f "$file" "$target_file"
 
-            # TODO: Try using the `change_configuration` function.
+            # change_configuration does not apply here either, this appends a
+            # comment header and a source line as one formatted unit, not a
+            # single key's value.
             # Add source $target_file to $configuration_file if not already added.
             source_line="source $target_file"
             if ! grep -qxF "$source_line" "$configuration_file"; then
@@ -223,7 +227,7 @@ change_configuration() {
     local configuration_file_path=$3
 
     if grep -q "^#*$key" "$configuration_file_path"; then
-        sudo sed -i "s/^#*$key.*/$key$value/" "$configuration_file_path"
+        sudo sed -i "s|^#*$key.*|$key$value|" "$configuration_file_path"
     else
         echo "$key$value" | sudo tee -a "$configuration_file_path" >/dev/null
     fi

--- a/scripts/helpers/security/dns.sh
+++ b/scripts/helpers/security/dns.sh
@@ -11,6 +11,7 @@ DNS_SCRIPT_DIRECTORY=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # Import functions.
 source "$DNS_SCRIPT_DIRECTORY/../functions/services.sh"
+source "$DNS_SCRIPT_DIRECTORY/../functions/filesystem.sh"
 
 # Initialize a flag to track whether a change was made.
 dns_changes_made=1
@@ -18,40 +19,19 @@ dns_changes_made=1
 # Constant variables for keeping the resolved configuration.
 RESOLVED_CONFIGURATION="/etc/systemd/resolved.conf"
 
-# TODO: Try using the `change_configuration` function.
-# Check if the 'DNSSEC' line already exists in the 'resolved.conf' file.
-if grep -q '^DNSSEC=' "$RESOLVED_CONFIGURATION"; then
-
-    # Check if 'DNSSEC' is set to 'yes', if not, replace it with 'DNSSEC=yes'
-    if ! grep -q '^DNSSEC=yes' "$RESOLVED_CONFIGURATION"; then
-        sudo sed -i 's/^DNSSEC=.*/DNSSEC=yes/' "$RESOLVED_CONFIGURATION"
-
-        # Set the dns_changes_made flag to 0 (true).
-        dns_changes_made=0
-    fi
-else
-
-    # If the 'DNSSEC' line doesn't exist, add 'DNSSEC=yes' to the end of the file
-    echo 'DNSSEC=yes' | sudo tee -a "$RESOLVED_CONFIGURATION" >/dev/null
+# Set 'DNSSEC' to 'yes', whether the line is missing, commented out, or set
+# to something else.
+if ! grep -q '^DNSSEC=yes' "$RESOLVED_CONFIGURATION"; then
+    change_configuration "DNSSEC=" "yes" "$RESOLVED_CONFIGURATION"
 
     # Set the dns_changes_made flag to 0 (true).
     dns_changes_made=0
 fi
 
-# Check if 'DNSOverTLS' line already exists in the 'resolved.conf' file.
-if grep -q '^DNSOverTLS=' "$RESOLVED_CONFIGURATION"; then
-
-    # Check if 'DNSOverTLS' is set to 'yes', if not, replace it with 'DNSOverTLS=yes'
-    if ! grep -q '^DNSOverTLS=yes' "$RESOLVED_CONFIGURATION"; then
-        sudo sed -i 's/^DNSOverTLS=.*/DNSOverTLS=yes/' "$RESOLVED_CONFIGURATION"
-
-        # Set the dns_changes_made flag to 0 (true).
-        dns_changes_made=0
-    fi
-else
-
-    # If the 'DNSOverTLS' line doesn't exist, add 'DNSOverTLS=yes' to the end of the file
-    echo 'DNSOverTLS=yes' | sudo tee -a "$RESOLVED_CONFIGURATION" >/dev/null
+# Set 'DNSOverTLS' to 'yes', whether the line is missing, commented out, or
+# set to something else.
+if ! grep -q '^DNSOverTLS=yes' "$RESOLVED_CONFIGURATION"; then
+    change_configuration "DNSOverTLS=" "yes" "$RESOLVED_CONFIGURATION"
 
     # Set the dns_changes_made flag to 0 (true).
     dns_changes_made=0

--- a/scripts/helpers/security/firewall.sh
+++ b/scripts/helpers/security/firewall.sh
@@ -90,7 +90,9 @@ if ! sudo ufw status | grep -q '123/udp'; then
     firewall_changes_made=0
 fi
 
-# TODO: Try using the `change_configuration` function.
+# change_configuration does not apply here, it replaces or appends a single
+# key's value, this needs a multi-line rule inserted before the COMMIT line,
+# appending after COMMIT would break the ufw rules file.
 # Check if ICMPv6 rule exists and if not add it.
 if ! grep -q 'ufw6-before-output -p ipv6-icmp -j ACCEPT' /etc/ufw/before6.rules; then
     log_info "Allowing ICMPv6 connections."

--- a/scripts/helpers/security/memory.sh
+++ b/scripts/helpers/security/memory.sh
@@ -11,6 +11,7 @@ MEMORY_SCRIPT_DIRECTORY=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # Import functions.
 source "$MEMORY_SCRIPT_DIRECTORY/../functions/packages.sh"
+source "$MEMORY_SCRIPT_DIRECTORY/../functions/filesystem.sh"
 
 # Constant variables for keeping the hardened memory allocator configuration.
 HARDENED_MEMORY_ALLOCATOR_CONFIGURATION="LD_PRELOAD=/usr/lib/libhardened_malloc.so"
@@ -19,11 +20,8 @@ HARDENED_MEMORY_ALLOCATOR_CONFIGURATION_DIRECTORY="/etc/environment"
 # Install hardened memory allocator.
 install_packages "hardened_malloc" "$AUR_PACKAGE_MANAGER" "Installing hardened memory allocator..."
 
-# TODO: Try using the `change_configuration` function.
 # Enable hardened memory allocator.
 if ! grep -q "^$HARDENED_MEMORY_ALLOCATOR_CONFIGURATION" "$HARDENED_MEMORY_ALLOCATOR_CONFIGURATION_DIRECTORY"; then
     log_info "Enabling hardened memory allocator..."
-
-    # Add 'LD_PRELOAD=/usr/lib/libhardened_malloc.so' to the end of the file.
-    echo "$HARDENED_MEMORY_ALLOCATOR_CONFIGURATION" | sudo tee -a "$HARDENED_MEMORY_ALLOCATOR_CONFIGURATION_DIRECTORY" >/dev/null
+    change_configuration "LD_PRELOAD=" "/usr/lib/libhardened_malloc.so" "$HARDENED_MEMORY_ALLOCATOR_CONFIGURATION_DIRECTORY"
 fi

--- a/scripts/helpers/security/nts.sh
+++ b/scripts/helpers/security/nts.sh
@@ -40,12 +40,11 @@ if [ "$are_nts_files_the_same" = "false" ]; then
     nts_changes_made=0
 fi
 
-# TODO: Try using the `change_configuration` function.
 # Add the seccomp filter option to the environment file only if not exists.
 if ! grep -q 'OPTIONS="-F 1"' "$NTS_SYSTEM_CONFIGURATION" 2>/dev/null; then
     log_info "Limiting access to encrypted network time security application..."
     sudo mkdir -p "$NTS_SYSTEM_CONFIGURATION_DIRECTORY"
-    echo 'OPTIONS="-F 1"' | sudo tee "$NTS_SYSTEM_CONFIGURATION" >/dev/null
+    change_configuration "OPTIONS=" '"-F 1"' "$NTS_SYSTEM_CONFIGURATION"
 
     # Set the nts_changes_made flag to 0 (true).
     nts_changes_made=0

--- a/test/integration/smoke.sh
+++ b/test/integration/smoke.sh
@@ -17,6 +17,8 @@ CONTAINER_NAME="arch-tuner-integration-smoke-$$"
 TARGETS=(
     "scripts/helpers/security/journald.sh"
     "scripts/helpers/security/automatic-updates.sh"
+    "scripts/helpers/essentials/pacman.sh"
+    "scripts/helpers/security/dns.sh"
 )
 
 docker build --platform=linux/amd64 -t "$IMAGE_NAME" -f "$REPOSITORY_ROOT/test/integration/Dockerfile" "$REPOSITORY_ROOT"


### PR DESCRIPTION
**What**:

1. **`change_configuration`**: Fix a `sed` delimiter collision, a key or value containing `/` broke the substitution, using `|` as the delimiter instead. Needed by `memory.sh`'s `LD_PRELOAD` path below.
2. **`pacman.sh`**: Use `change_configuration` to enable `Color` and `ParallelDownloads`.
3. **`aur.sh`**: Use `change_configuration` for `CleanMethod` and each paru configuration option.
4. **`dns.sh`**: Collapse the `DNSSEC`/`DNSOverTLS` missing-vs-commented-vs-wrong-value branches into one `change_configuration` call each.
5. **`memory.sh`**: Use `change_configuration` for the `LD_PRELOAD` hardened allocator line.
6. **`nts.sh`**: Use `change_configuration` for the `chronyd` seccomp filter option.
7. **`firewall.sh`**: Document why its ICMPv6 rule stays a `sed` insertion, `change_configuration` only replaces or appends a single key, this needs a multi-line rule inserted before `COMMIT`, appending after it would break the `ufw` rules file.
8. **`shell.sh`**: Use the existing `append_line_to_file` helper for the `/etc/shells` entry instead of hand-rolled `grep`/`tee`, `change_configuration` does not fit a plain path list either.
9. **`filesystem.sh`**: Resolve its own two `change_configuration` `TODO`s with a comment explaining why neither `append_line_to_file` nor `configure_fish_shell_files`'s multi-line append fit that model.
10. **Integration coverage**: Add `pacman.sh` and `dns.sh` to the Docker integration smoke list, both proved container-safe while verifying this change.

**Why**:

Resolves the `change_configuration` item in `documents/roadmap.md`'s backlog. Several helpers still edited configuration files with ad-hoc `sed`/`grep` instead of the shared helper, each was converted where the single-key model actually fits, and left alone with an explanation where it does not.