### PR TITLE
Clean the pacman cache with paccache in aur.sh

### DIFF
--- a/scripts/helpers/essentials/aur.sh
+++ b/scripts/helpers/essentials/aur.sh
@@ -137,4 +137,8 @@ yay)
     ;;
 esac
 
-# TODO: Clean AUR cache configuration using paccache.
+# Clean the pacman package cache, keeping only the most recent version of
+# each package. AUR packages install through pacman too, so their old
+# cached versions build up here just like official repository packages.
+install_packages "pacman-contrib" "$ARCH_PACKAGE_MANAGER" "Installing cache clearing package..."
+sudo paccache -r


### PR DESCRIPTION
**What**:

Install `pacman-contrib` and run `paccache -r` at the end of `aur.sh`, keeping only the most recent cached version of each package.

**Why**:

Resolves the `paccache` item in `documents/roadmap.md`'s backlog. `pacman.sh`'s hook already runs `paccache -r` on future transactions, but bootstrapping an AUR helper pulls in a large, disk-heavy dependency chain (`rustup`, `cargo`, `base-devel`), worth an immediate cleanup right after rather than waiting for the next transaction to trigger the hook.