### PR TITLE
Remove pacman-hook-only packages during system reset

### DIFF
--- a/documents/roadmap.md
+++ b/documents/roadmap.md
@@ -11,6 +11,14 @@ integrity monitoring, automatic updates, firewall and DNS refinement, Docker eng
 and essentials and usbguard trimming are merged to `main`. Every security helper is wired into
 `security.sh`, and the hardening checklist in `README.md` reflects what actually runs.
 
+A `bats` unit test harness (`test/`) and a Docker-based Arch Linux integration harness
+(`test/integration/`) are merged, see `AGENTS.md`. `pacman.sh`, `aur.sh`, `dns.sh`, `memory.sh`,
+and `nts.sh` now use the shared `change_configuration` function instead of ad-hoc `sed`/`grep`,
+`shell.sh` uses `append_line_to_file` instead, and `firewall.sh` and `filesystem.sh` keep theirs
+where neither helper's model fits. `aur.sh` cleans the pacman cache with `paccache` after
+bootstrapping an AUR helper, and `reset_system_to_clean_state` removes packages that only existed
+to support a pacman hook.
+
 ## Remaining
 
 - Encrypted swap, tracked as a `TODO` in `privacy.sh`.
@@ -27,10 +35,5 @@ and essentials and usbguard trimming are merged to `main`. Every security helper
 
 ## Backlog
 
-- Adopt the existing `change_configuration` function in `pacman.sh`, `aur.sh`, `dns.sh`,
-  `memory.sh`, `firewall.sh`, `nts.sh`, `shell.sh`, and `filesystem.sh`, which still edit
-  configuration files with ad-hoc `sed`/`grep` instead of the shared helper.
-- Clean the AUR cache using `paccache` in `aur.sh`.
-- Remove packages that are only used inside pacman hooks, tracked in `system.sh`.
 - Integration with a future containers repository for application hosting. Traefik, filebrowser,
   uptime-kuma, and tailscale stay out of scope for this repository.

--- a/scripts/helpers/functions/system.sh
+++ b/scripts/helpers/functions/system.sh
@@ -189,7 +189,18 @@ reset_system_to_clean_state() {
     # Extract package names from the list.
     FRESH_INSTALLATION_PACKAGES=$(awk '{print $1}' "$TEMPORARY_PACKAGE_LIST")
 
-    # TODO: Remove packages used in pacman hooks.
+    # Remove packages that only exist to support a pacman hook this toolkit
+    # deployed, they were installed explicitly and would otherwise survive
+    # this reset instead of being cleaned up as orphans.
+    declare -a HOOK_ONLY_PACKAGES=(
+        pacman-contrib
+    )
+    for hook_only_package in "${HOOK_ONLY_PACKAGES[@]}"; do
+        if pacman -Q "$hook_only_package" &>/dev/null; then
+            log_info "Removing hook-only package '$hook_only_package'..."
+            sudo "$ARCH_PACKAGE_MANAGER" -Rns --noconfirm "$hook_only_package"
+        fi
+    done
 
     # Remove all AUR packages.
     log_info "Removing all AUR packages..."


### PR DESCRIPTION
**What**:

1. **`system.sh`**: `reset_system_to_clean_state` now removes `pacman-contrib`, installed only to support `pacman.sh`'s `paccache` hook, before the orphan cleanup step.
2. **`documents/roadmap.md`**: Close out the backlog entries for `change_configuration` adoption, `paccache` cleanup, and hook-only package removal, all merged now.

**Why**:

Resolves the last `system.sh` item in `documents/roadmap.md`'s backlog. `pacman-contrib` installs explicitly, not as a dependency, so the existing orphan-removal step never catches it, it would survive a reset that is supposed to return the system to a clean Arch install.