### PR TITLE
Wire up encrypted swap, PAM/U2F, AppArmor, Secure Boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ The toolkit implements the following hardening measures:
 - Mount points hardening
 - SUID/SGID stripping with pacman hook
 - Antivirus with daily scan timer
+- Encrypted swap with a random, never-persisted per-boot key
+- Optional PAM U2F/FIDO2 authentication for sudo, needs a hardware key
+- AppArmor Mandatory Access Control, complain mode by default
+- Secure Boot key creation, enrollment and signing stay manual, see `AGENTS.md`
 
 ## Roadmap
 

--- a/documents/roadmap.md
+++ b/documents/roadmap.md
@@ -19,13 +19,16 @@ where neither helper's model fits. `aur.sh` cleans the pacman cache with `paccac
 bootstrapping an AUR helper, and `reset_system_to_clean_state` removes packages that only existed
 to support a pacman hook.
 
+Encrypted swap (`privacy/swap.sh`), PAM U2F/FIDO2 authentication for `sudo`
+(`security/pam-u2f.sh`), AppArmor Mandatory Access Control in complain mode
+(`security/apparmor.sh`), and Secure Boot key creation (`security/secure-boot.sh`) are merged and
+wired into `privacy.sh`/`security.sh`. Enrolling Secure Boot keys into firmware and signing the
+bootloader and kernel stay a manual, administrator-reviewed step, see `AGENTS.md`, as does
+enabling AppArmor's kernel `lsm=` parameter and enforcing any profile beyond complain mode.
+
 ## Remaining
 
-- Encrypted swap, tracked as a `TODO` in `privacy.sh`.
 - A Linux kernel runtime guard, once one exists with support for current kernels.
-- Secure Boot.
-- Pluggable Authentication Modules and a U2F/FIDO2 authenticator choice.
-- Mandatory Access Control via AppArmor and its policies and profiles.
 
 ## Rejected
 

--- a/scripts/utilities/privacy.sh
+++ b/scripts/utilities/privacy.sh
@@ -20,4 +20,5 @@ sh $PRIVACY_SCRIPT_DIRECTORY/../helpers/privacy/network.sh
 # Configure umask.
 sh $PRIVACY_SCRIPT_DIRECTORY/../helpers/privacy/umask.sh
 
-# TODO: Implement encrypted swap.
+# Configure encrypted swap.
+sh $PRIVACY_SCRIPT_DIRECTORY/../helpers/privacy/swap.sh

--- a/scripts/utilities/security.sh
+++ b/scripts/utilities/security.sh
@@ -41,9 +41,15 @@ sh $SECURITY_SCRIPT_DIRECTORY/../helpers/security/firewall.sh
 sh $SECURITY_SCRIPT_DIRECTORY/../helpers/security/ids.sh
 
 # TODO: Implement Linux kernel runtime guard when there is support for newer kernels.
-# TODO: Implement Secure Boot process.
-# TODO: Implement Pluggable Authentication Modules (PAM) and U2F/FIDO2 authenticator choice.
-# TODO: Implement Mandatory Access Control via AppArmor and its policies/profiles.
+
+# Manage Secure Boot keys.
+sh $SECURITY_SCRIPT_DIRECTORY/../helpers/security/secure-boot.sh
+
+# Configure PAM U2F/FIDO2 authentication for sudo.
+sh $SECURITY_SCRIPT_DIRECTORY/../helpers/security/pam-u2f.sh
+
+# Configure Mandatory Access Control via AppArmor.
+sh $SECURITY_SCRIPT_DIRECTORY/../helpers/security/apparmor.sh
 
 # Configure mount points for extra hardening.
 sh $SECURITY_SCRIPT_DIRECTORY/../helpers/security/mount.sh


### PR DESCRIPTION
**What**:

1. **`privacy.sh`**: call `swap.sh`, replacing its `TODO`.
2. **`security.sh`**: call `secure-boot.sh`, `pam-u2f.sh`, and `apparmor.sh`, replacing their `TODO`s. The kernel runtime guard `TODO` stays, still blocked upstream.
3. **`README.md`**: add the four helpers to the hardening checklist.
4. **`documents/roadmap.md`**: move them from `Remaining` to `Status`.

**Why**:

Closes out `documents/roadmap.md`'s `Remaining` section down to the one item that has always been blocked on upstream tooling. Matches the historical `chore/wire-up-and-docs` pattern this repo already used for the first hardening PR series, standalone helper PRs first, one dedicated wiring PR after they merge.