### PR TITLE
Reboot after the essentials and privacy phases too

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -85,6 +85,9 @@ for script in "${ORDERED_SCRIPTS[@]}"; do
 
                 # Change the completion flag value to 0 (true).
                 change_flag_value "$completion_flag" 0
+
+                # Reboot now, the rest of the phases need to be rerun afterward.
+                reboot_system "${!completion_flag}" "$completion_flag"
             elif [ "$script" == "security" ]; then
                 log_success "Installation procedure finished!"
                 log_success "Your system is ready to use!"

--- a/test/install.bats
+++ b/test/install.bats
@@ -1,0 +1,9 @@
+#!/usr/bin/env bats
+
+@test "install.sh reboots after every phase, not just security" {
+    # Regression guard: essentials and privacy shared one reboot_system call,
+    # security had its own, only the security one survived a past refactor.
+    install_script="$BATS_TEST_DIRNAME/../install.sh"
+
+    [ "$(grep -c 'reboot_system ' "$install_script")" -eq 2 ]
+}


### PR DESCRIPTION
**What**:

Call `reboot_system` after the essentials and privacy phases in `install.sh`, matching what it already does for the security phase, and add a regression test in `test/install.bats`.

**Why**:

`install.sh`'s own comment right above this code says "Reboot system for the rest of the scripts," and both `AGENTS.md` and `README.md` document install.sh as rebooting between phases, but the actual reboot call only ever existed for the security phase, essentials and privacy just updated their completion flag and fell through to the next phase in the same run. This left applied-but-unbooted changes, like the encrypted swap mapping added in the privacy phase, silently pending until whatever eventually triggered the one reboot at the very end.