### PR TITLE
Cut redundant README sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,8 @@
 # Arch Server Hardening Toolkit
 
-An Arch Linux server hardening toolkit for securing and hardening your Arch-based server, whether a VPS, a cloud instance, or bare metal. Originally evolved from an Arch desktop post-install toolkit, this project is now focused exclusively on server hardening.
+An Arch Linux server hardening toolkit for securing a VPS, a cloud instance, or bare metal across three phases: essentials, privacy, and security. It evolved from an Arch desktop post-install toolkit; desktop-only components like display managers and desktop environments have since been removed to keep it lean and server-focused.
 
 See [`AGENTS.md`](AGENTS.md) if you are an agent.
-
-## Why Server-Only
-
-This toolkit is purpose-built for Arch server deployments, whether a VPS, a cloud instance, or bare metal, focusing on essential security hardening, privacy protection, and system essentials. Features that were relevant for desktop systems have been removed to keep the toolkit lean and secure for server environments.
-
-Desktop-specific components like display managers, graphical login interfaces, and desktop environments have all been removed.
-
-## What It Includes
-
-- **Essentials Phase**: Core system setup including package manager configuration, essential packages, and basic system utilities
-- **Privacy Phase**: System hardening for privacy, including secure networking configurations and privacy-enhancing tools
-- **Security Phase**: Comprehensive security hardening including firewall, antivirus, DNSSEC, and system hardening measures
-
-## Future Plans
-
-This toolkit is prepared to integrate with a future containers repository that will manage container applications. For now, container applications like filebrowser, uptime-kuma, traefik, and tailscale are intentionally out of scope here.
 
 ## Installation
 
@@ -90,11 +74,6 @@ The toolkit implements the following hardening measures:
 - AppArmor Mandatory Access Control, complain mode by default
 - Secure Boot key creation, enrollment and signing stay manual, see `AGENTS.md`
 
-## Roadmap
-
-See [`documents/roadmap.md`](documents/roadmap.md) for what is merged, what is in review, and
-what remains.
-
 ## Contributing
 
 Contributions are welcome. See [`AGENTS.md`](AGENTS.md) for repository conventions and the merge
@@ -103,8 +82,3 @@ workflow.
 ## License
 
 MIT License. See `LICENSE` file for details.
-
-## Links
-
-- [Arch Wiki](https://wiki.archlinux.org/)
-- [Arch Linux Documentation](https://wiki.archlinux.org/index.php/Main_page)


### PR DESCRIPTION
**What**:

1. Trims README to description, features, install, and license/contribution, folding the intro and "Why Server-Only" into one paragraph and dropping "What It Includes", "Future Plans", "Roadmap", and "Links" as duplicates of the Hardening Checklist and roadmap link.

**Why**:

Keep the README scannable, the removed sections restated content already covered elsewhere.