### PR TITLE
Make SSH port configurable instead of hardcoded 2222

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The toolkit implements the following hardening measures:
 
 - Pacman signature verification
 - Non-root administrative user creation
-- SSH key-only authentication on port 2222
+- SSH key-only authentication on a custom port chosen at install time, never the default 22
 - Sudoers hardening
 - Fail2ban installation and configuration
 - Kernel sysctl hardening
@@ -65,7 +65,7 @@ The toolkit implements the following hardening measures:
 - Audit daemon configuration
 - Automatic daily system updates
 - Docker engine hardening: user namespaces, no new privileges, ICC off
-- Firewall denying incoming connections except SSH 2222
+- Firewall denying incoming connections except the chosen SSH port
 - DNS over TLS
 - Mount points hardening
 - SUID/SGID stripping with pacman hook

--- a/scripts/helpers/functions/ui.sh
+++ b/scripts/helpers/functions/ui.sh
@@ -6,6 +6,9 @@ UI_SCRIPT_DIRECTORY=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # Import log functions.
 source "$UI_SCRIPT_DIRECTORY/logs.sh"
 
+# Import state functions.
+source "$UI_SCRIPT_DIRECTORY/state.sh"
+
 # Function to ask for user approval before proceeding.
 # Usage:
 #   ask_for_user_backup_before_proceeding
@@ -184,4 +187,32 @@ prompt_user_input() {
     fi
 
     echo "$input"
+}
+
+# Function to get the SSH port, prompting for it once and persisting the
+# choice across scripts and re-runs. Never allows the classic port 22.
+# Usage:
+#   get_ssh_port
+get_ssh_port() {
+    source_state
+
+    # Reuse the already-chosen port without prompting again.
+    if [ -n "$SSH_PORT" ]; then
+        echo "$SSH_PORT"
+        return
+    fi
+
+    local port=""
+    while :; do
+        port=$(prompt_user_input "Enter SSH port (1024-65535, avoid the classic 22)" "2222")
+
+        if [[ "$port" =~ ^[0-9]+$ ]] && [ "$port" -ge 1024 ] && [ "$port" -le 65535 ] && [ "$port" -ne 22 ]; then
+            break
+        fi
+
+        log_error "Invalid SSH port: '$port'. Use a number between 1024 and 65535, not 22."
+    done
+
+    change_flag_value "SSH_PORT" "$port"
+    echo "$port"
 }

--- a/scripts/helpers/security/fail2ban.sh
+++ b/scripts/helpers/security/fail2ban.sh
@@ -14,6 +14,7 @@ source "$FAIL2BAN_SCRIPT_DIRECTORY/../functions/logs.sh"
 source "$FAIL2BAN_SCRIPT_DIRECTORY/../functions/packages.sh"
 source "$FAIL2BAN_SCRIPT_DIRECTORY/../functions/services.sh"
 source "$FAIL2BAN_SCRIPT_DIRECTORY/../functions/filesystem.sh"
+source "$FAIL2BAN_SCRIPT_DIRECTORY/../functions/ui.sh"
 
 # Constant variables for the fail2ban configuration paths.
 FAIL2BAN_CONFIGURATION="/etc/fail2ban/jail.local"
@@ -31,6 +32,12 @@ if [[ "$are_fail2ban_files_the_same" != "true" ]]; then
 else
     log_info "Fail2ban configuration already up to date."
 fi
+
+# Apply the chosen SSH port, shared with ssh.sh and firewall.sh via state.sh.
+# fail2ban's sshd jail otherwise resolves its ban target through the "ssh"
+# service name, which means port 22, and would silently miss the real port.
+ssh_port=$(get_ssh_port)
+change_configuration "port = " "$ssh_port" "$FAIL2BAN_CONFIGURATION"
 
 # Enable and start the fail2ban service.
 enable_service fail2ban

--- a/scripts/helpers/security/firewall.sh
+++ b/scripts/helpers/security/firewall.sh
@@ -12,6 +12,7 @@ FIREWALL_SCRIPT_DIRECTORY=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # Import functions.
 source "$FIREWALL_SCRIPT_DIRECTORY/../functions/packages.sh"
 source "$FIREWALL_SCRIPT_DIRECTORY/../functions/services.sh"
+source "$FIREWALL_SCRIPT_DIRECTORY/../functions/ui.sh"
 
 # Initialize a flag indicating if a firewall change has been made.
 firewall_changes_made=1
@@ -38,10 +39,12 @@ if ! sudo ufw status verbose | grep -q 'Default: deny (incoming), deny (outgoing
     firewall_changes_made=0
 fi
 
-# Allow SSH on port 2222/tcp (covers both IPv4 and IPv6).
-if ! sudo ufw status | grep -q '2222/tcp'; then
-    log_info "Allowing SSH (2222/TCP) connections."
-    sudo ufw allow in 2222/tcp
+# Allow SSH on the chosen port (covers both IPv4 and IPv6), shared with
+# ssh.sh and fail2ban.sh via state.sh so all three agree on the same port.
+ssh_port=$(get_ssh_port)
+if ! sudo ufw status | grep -q "$ssh_port/tcp"; then
+    log_info "Allowing SSH ($ssh_port/TCP) connections."
+    sudo ufw allow in "$ssh_port/tcp"
 
     # Set the firewall_changes_made flag to 0 (true).
     firewall_changes_made=0

--- a/scripts/helpers/security/ssh.sh
+++ b/scripts/helpers/security/ssh.sh
@@ -13,6 +13,7 @@ SSH_SCRIPT_DIRECTORY=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 source "$SSH_SCRIPT_DIRECTORY/../functions/logs.sh"
 source "$SSH_SCRIPT_DIRECTORY/../functions/services.sh"
 source "$SSH_SCRIPT_DIRECTORY/../functions/filesystem.sh"
+source "$SSH_SCRIPT_DIRECTORY/../functions/ui.sh"
 
 # Constant variables for the SSH server configuration paths.
 SSH_CONFIGURATION="/etc/ssh/sshd_config"
@@ -30,6 +31,10 @@ if [[ "$are_ssh_files_the_same" != "true" ]]; then
 else
     log_info "SSH configuration already up to date."
 fi
+
+# Apply the chosen SSH port, shared with firewall.sh and fail2ban.sh via state.sh.
+ssh_port=$(get_ssh_port)
+change_configuration "Port " "$ssh_port" "$SSH_CONFIGURATION"
 
 # Start the SSH service.
 start_service sshd

--- a/test/ui.bats
+++ b/test/ui.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+
+setup() {
+    ui_under_test="$BATS_TEST_DIRNAME/../scripts/helpers/functions/ui.sh"
+
+    export ARCH_TUNER_STATE_DIRECTORY="$BATS_TEST_TMPDIR"
+}
+
+@test "get_ssh_port rejects the classic port 22 and prompts again" {
+    run bash -c "source '$ui_under_test' && printf '22\n2244\n' | get_ssh_port"
+
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | tail -n 1)" = "2244" ]
+}
+
+@test "get_ssh_port rejects a non-numeric or out-of-range port" {
+    run bash -c "source '$ui_under_test' && printf 'abc\n70000\n2244\n' | get_ssh_port"
+
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | tail -n 1)" = "2244" ]
+}
+
+@test "get_ssh_port accepts a valid custom port on the first try" {
+    run bash -c "source '$ui_under_test' && printf '2244\n' | get_ssh_port"
+
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | tail -n 1)" = "2244" ]
+}
+
+@test "get_ssh_port persists the chosen port and does not reprompt" {
+    bash -c "source '$ui_under_test' && printf '2244\n' | get_ssh_port" >/dev/null
+
+    run bash -c "source '$ui_under_test' && get_ssh_port </dev/null"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "2244" ]
+}


### PR DESCRIPTION
## What
Adds `get_ssh_port` to `ui.sh`, prompting once for a custom SSH port (1024-65535, never 22) and persisting it via `state.sh`. `ssh.sh`, `firewall.sh`, and `fail2ban.sh` all read the same persisted value instead of hardcoding `2222`, keeping `sshd_config`'s `Port`, the `ufw` inbound rule, and `jail.local`'s `[sshd] port` in sync.

## Why
The port was hardcoded, so operators couldn't choose a non-default port at install time, and any manual change risked the known `fail2ban`/`ufw`/`sshd_config` drift called out in `AGENTS.md`.