### PR TITLE
Prompt for hostname once during essentials setup

### DIFF
--- a/scripts/helpers/essentials/hostname.sh
+++ b/scripts/helpers/essentials/hostname.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Catch exit signal (CTRL + C), to terminate the whole script.
+trap "exit" INT
+
+# Terminate script on error.
+set -e
+
+# Constant variable of the scripts' working directory to use for relative paths.
+HOSTNAME_SCRIPT_DIRECTORY=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+# Import functions.
+source "$HOSTNAME_SCRIPT_DIRECTORY/../functions/ui.sh"
+source "$HOSTNAME_SCRIPT_DIRECTORY/../functions/state.sh"
+
+# Skip prompting if a hostname has already been chosen on a previous run.
+source_state
+if [ "$HOSTNAME_SET" = "1" ]; then
+    log_info "Hostname already configured."
+else
+    current_hostname=$(hostnamectl --static)
+
+    # Prompt until a valid RFC 1123 hostname label is given: lowercase
+    # letters, digits and hyphens, 1-63 characters, no leading/trailing hyphen.
+    while :; do
+        hostname=$(prompt_user_input "Enter hostname for this machine" "$current_hostname")
+
+        if [[ "$hostname" =~ ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$ ]]; then
+            break
+        fi
+
+        log_error "Invalid hostname: '$hostname'. Use up to 63 lowercase letters, digits, or hyphens, not starting or ending with a hyphen."
+    done
+
+    sudo hostnamectl set-hostname "$hostname"
+    log_success "Hostname set to $hostname."
+
+    change_flag_value "HOSTNAME_SET" 1
+fi

--- a/scripts/utilities/essentials.sh
+++ b/scripts/utilities/essentials.sh
@@ -36,3 +36,6 @@ sh $ESSENTIALS_SCRIPT_DIRECTORY/../helpers/essentials/terminal.sh
 
 # Install and configure shell.
 sh $ESSENTIALS_SCRIPT_DIRECTORY/../helpers/essentials/shell.sh
+
+# Set the machine's hostname if not already configured.
+sh $ESSENTIALS_SCRIPT_DIRECTORY/../helpers/essentials/hostname.sh

--- a/test/hostname.bats
+++ b/test/hostname.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+
+setup() {
+    hostname_under_test="$BATS_TEST_DIRNAME/../scripts/helpers/essentials/hostname.sh"
+    export ARCH_TUNER_STATE_DIRECTORY="$BATS_TEST_TMPDIR"
+
+    stub_directory="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$stub_directory"
+
+    cat >"$stub_directory/sudo" <<'EOS'
+#!/bin/bash
+exec "$@"
+EOS
+    chmod +x "$stub_directory/sudo"
+
+    export HOSTNAME_STUB_FILE="$BATS_TEST_TMPDIR/hostname_set_to"
+    cat >"$stub_directory/hostnamectl" <<EOS
+#!/bin/bash
+case "\$1" in
+--static) echo "archlinux" ;;
+set-hostname) echo "\$2" >"$HOSTNAME_STUB_FILE" ;;
+esac
+EOS
+    chmod +x "$stub_directory/hostnamectl"
+
+    export PATH="$stub_directory:$PATH"
+}
+
+@test "hostname.sh rejects an invalid hostname and accepts a valid one" {
+    run bash -c "printf 'Not_Valid!\nmy-host\n' | bash '$hostname_under_test'"
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$HOSTNAME_STUB_FILE")" = "my-host" ]
+}
+
+@test "hostname.sh persists HOSTNAME_SET after setting the hostname" {
+    bash -c "printf 'my-host\n' | bash '$hostname_under_test'" >/dev/null
+
+    grep -qxF 'HOSTNAME_SET=1' "$ARCH_TUNER_STATE_DIRECTORY/state.sh"
+}
+
+@test "hostname.sh does not prompt again once HOSTNAME_SET is 1" {
+    bash -c "printf 'my-host\n' | bash '$hostname_under_test'" >/dev/null
+
+    run bash -c "bash '$hostname_under_test' </dev/null"
+
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## What

Adds `scripts/helpers/essentials/hostname.sh`, wired into `essentials.sh` after `shell.sh`. Prompts for a hostname (validated against RFC 1123 label rules), applies it via `hostnamectl set-hostname`, and persists a `HOSTNAME_SET` flag via `state.sh` so it never prompts again on subsequent runs.

## Why

The toolkit had no way to set the machine's hostname, operators had to do it manually outside the install flow. Asking once and remembering matches the existing `*_COMPLETED` flag pattern used elsewhere in `state.sh`.