### PR TITLE
Bring containers-repository integration into scope

### DIFF
--- a/documents/containers-integration.md
+++ b/documents/containers-integration.md
@@ -1,0 +1,39 @@
+# Containers integration prep
+
+Planning note for wiring `https://github.com/xrhstosmour/containers` Docker Compose services onto
+a host this toolkit has hardened. This repository does not install any container, each service
+lands as its own future pull request against that repository. See `documents/roadmap.md` for how
+this fits the overall plan.
+
+## Prerequisite
+
+The containers repository's own `README.md` requires a shared Docker network before starting any
+service:
+
+```bash
+docker network create internal
+```
+
+Run this once per host before starting any container from that repository.
+
+## Port matrix already open on this host
+
+All the ports below are inbound, opened by `security/firewall.sh` except the SSH port, which is
+opened by `security/ssh.sh`:
+
+- A custom SSH port, chosen at install time, never the default 22.
+- `80/tcp`: Traefik, HTTP redirect to HTTPS.
+- `443/tcp`: Traefik, HTTPS, fronts Netbird and Authelia.
+- `3478/udp`: Netbird's Coturn STUN/TURN, cannot be proxied.
+
+Authelia gets no separate inbound port, it's only reachable through Traefik on `443/tcp`.
+
+## Upcoming pull requests
+
+- [ ] Wire Traefik (`networking/proxies/traefik`, already in the containers repository) as the
+      reverse proxy in front of Authelia and Netbird.
+- [ ] Add Authelia to the containers repository, routed through Traefik.
+- [ ] Add a self-hosted Netbird stack (management, signal, relay, Coturn) to the containers
+      repository, routed through Traefik per its recommended reverse-proxy architecture.
+
+Each of these is scoped and merged independently.

--- a/documents/roadmap.md
+++ b/documents/roadmap.md
@@ -37,7 +37,16 @@ enabling AppArmor's kernel `lsm=` parameter and enforcing any profile beyond com
 - PAM U2F/FIDO2 authentication for `sudo`. Needs a hardware authenticator physically attached to
   the machine, not available here, dropped rather than kept as a feature nobody can use or verify.
 
+## Containers integration
+
+Traefik, Authelia, and a self-hosted Netbird stack, from
+`https://github.com/xrhstosmour/containers`, are now in scope. Traefik already exists there
+(`networking/proxies/traefik`), Authelia and a self-hosted Netbird stack still need adding. Each
+lands as its own future pull request, this repository only opens the firewall ports and documents
+the prerequisites they need, see `documents/containers-integration.md`. This repository
+standardizes on Netbird instead of Tailscale for VPN.
+
 ## Backlog
 
-- Integration with a future containers repository for application hosting. Traefik, filebrowser,
-  uptime-kuma, and tailscale stay out of scope for this repository.
+- `filebrowser` and `uptime-kuma` from the `xrhstosmour/containers` repository stay out of scope
+  for now.


### PR DESCRIPTION
## What
Replaces the roadmap's "stays out of scope" backlog note for containers-repository integration with an in-scope plan, and adds `documents/containers-integration.md`: the `docker network create internal` prerequisite from that repository's own README, the port matrix opened by #68/#69, and a checklist of upcoming per-container pull requests (Traefik wiring, Authelia, self-hosted Netbird). No shell script changes.

## Why
Netbird, Authelia, and Traefik containers from `https://github.com/xrhstosmour/containers` are now planned for this VPS, so the roadmap should reflect that instead of listing it as deliberately out of scope. `filebrowser` and `uptime-kuma` stay out of scope for now.