### PR TITLE
Restore starship prompt and add shell abbreviations

### DIFF
--- a/scripts/configurations/essentials/shell/abbreviations.fish
+++ b/scripts/configurations/essentials/shell/abbreviations.fish
@@ -11,6 +11,8 @@ abbr pr "paru -Rns --noconfirm"
 abbr ip "ip -br a | grep UP | awk '{print \"Interface: \" \$1 \"\nIPv4: \" \$3}'"
 abbr po "sudo systemctl poweroff"
 abbr zzz "sudo systemctl suspend"
+abbr sm "btm"
+abbr ff "fastfetch"
 
 # Terminal tools abbreviations.
 abbr cat "bat"
@@ -25,6 +27,9 @@ abbr h "atuin history list"
 abbr hs "atuin search -i"
 abbr cl "clear"
 abbr rmdp "keep_best_file | xargs rm -v"
+abbr ls "eza --long --all --icons --color=always --group-directories-first --git"
+abbr eva "calc"
+abbr dl "aria2c -x 10 "
 
 # Services abbreviations.
 abbr sc "sudo systemctl"
@@ -35,3 +40,11 @@ abbr sce "sudo systemctl enable"
 abbr scstp "sudo systemctl stop"
 abbr scd "sudo systemctl disable"
 abbr scrr "sudo systemctl reload-or-restart"
+
+# Docker abbreviations.
+abbr d "docker"
+abbr dc "docker compose"
+abbr dcu "docker compose up --build -d"
+abbr dcd "docker compose down"
+abbr de --set-cursor "docker compose exec % /bin/bash"
+abbr dcl "docker compose down -v --remove-orphans && echo y | docker system prune -a --volumes"

--- a/scripts/configurations/essentials/shell/configuration.fish
+++ b/scripts/configurations/essentials/shell/configuration.fish
@@ -1,3 +1,6 @@
+# Enable starship prompt.
+starship init fish | source
+
 # Enable zoxide at fish prompt.
 zoxide init fish | source
 

--- a/scripts/configurations/essentials/shell/starship.toml
+++ b/scripts/configurations/essentials/shell/starship.toml
@@ -1,0 +1,126 @@
+# Base configuration.
+command_timeout = 10000
+add_newline = true
+
+# Command duration.
+[cmd_duration]
+min_time = 500
+format = " 󱎫 [$duration]($style) "
+style = "bold italic #87A752"
+
+# Directory.
+[directory]
+truncation_length = 5
+format = "[$path]($style)[$lock_symbol]($lock_style) "
+style = "bold cyan"
+
+# Hostname.
+[hostname]
+ssh_only = true
+format = "[<$hostname>]($style)"
+trim_at = "-"
+style = "bold dimmed white"
+
+# Character.
+[character]
+success_symbol = "[➜](bold green) "
+error_symbol = "[✖](bold red) "
+
+# Packages.
+[package]
+disabled = false
+
+# Background jobs.
+[jobs]
+format = "[$symbol$jobs]($style) "
+symbol = "🔃 "
+style = "bold blue"
+
+# Git.
+[git_branch]
+format = "on [$symbol$branch]($style) "
+symbol = ""
+style = "bold yellow"
+
+[git_commit]
+commit_hash_length = 4
+style = "bold white"
+
+[git_state]
+format = '[\($state( $progress_current of $progress_total)\)]($style) '
+
+[git_status]
+conflicted = "󰞇 "
+ahead = "󰶣 ×${count} "
+behind = "󰶡 ×${count} "
+diverged = "󰶣 ×${ahead_count} 󰶡 ×${behind_count} "
+untracked = "󰇘 ×${count} "
+stashed = "󰏗 ×${count} "
+modified = "󰏫 ×${count} "
+staged = "󰐖 ×${count} "
+renamed = "󰑕 ×${count} "
+deleted = "󰆴 ×${count} "
+style = "bright-white"
+format = "$all_status$ahead_behind"
+
+# Languages & Tools.
+[nodejs]
+format = "|  $version "
+style = "bold green"
+
+[rust]
+format = "|  $version "
+style = "bold red"
+
+[python]
+format = "|  $version "
+style = "bold blue"
+
+[golang]
+format = "|  $version "
+style = "bold cyan"
+
+[java]
+format = "|  $version "
+style = "bold purple"
+
+[docker_context]
+format = "|  $context "
+style = "blue bold"
+
+[c]
+format = "|  $version "
+style = "bold #d75f00"
+
+[dotnet]
+format = "|  $version "
+style = "bold blue"
+
+[dart]
+format = "|  $version "
+style = "bold cyan"
+
+[ruby]
+format = "|  $version "
+style = "bold red"
+
+[php]
+format = "| 󰑄 $version "
+style = "bold purple"
+
+[lua]
+format = "|  $version "
+style = "bold blue"
+
+[cpp]
+format = "|  $version "
+style = "bold blue"
+
+[aws]
+disabled = true
+
+[gcloud]
+disabled = true
+
+[kubernetes]
+disabled = true

--- a/scripts/configurations/essentials/terminal/fastfetch/config.jsonc
+++ b/scripts/configurations/essentials/terminal/fastfetch/config.jsonc
@@ -1,0 +1,123 @@
+{
+    "$schema": "https://github.com/fastfetch-cli/fastfetch/raw/dev/doc/json_schema.json",
+    "logo": {
+        "type": "auto",
+        "padding": {
+            "top": 2
+        },
+        "color": {
+            "1": "blue",
+            "2": "blue",
+            "3": "blue",
+            "4": "blue",
+            "5": "blue",
+            "6": "blue",
+            "7": "blue",
+            "8": "blue",
+            "9": "blue"
+        }
+    },
+    "general": {},
+    "display": {
+        "disableLinewrap": false,
+        "separator": "",
+        "temp": {
+            "unit": "C"
+        },
+        "size": {
+            "binaryPrefix": "jedec"
+        },
+        "key": {
+            "width": 16
+        },
+        "constants": [
+            // Background key color.
+            "\u001b[48;2;43;43;69m",
+            // Background output color.
+            "\u001b[48;2;56;59;78m",
+            // Vertical bar at the start of the line and 50th character.
+            "\u001b[90m│                                   │\u001b[35D\u001b[39m"
+        ]
+    },
+    "modules": [
+        {
+            "type": "custom",
+            "key": "{#90}╭─────────────╮",
+            "format": "{#90}╭───────────────────────────────────╮"
+        },
+        {
+            "type": "title",
+            "key": "{#90}│ {#93}Host        {#90}│",
+            "format": "{$3}{host-name}"
+        },
+        {
+            "type": "os",
+            "key": "{#90}│ {#93}OS          {#90}│",
+            "format": "{$3}{name} {#2}[{version}]"
+        },
+        {
+            "type": "kernel",
+            "key": "{#90}│ {#93}Kernel      {#90}│",
+            "format": "{$3}{sysname} {#2}[{release}]"
+        },
+        {
+            "type": "bios",
+            "key": "{#90}│ {#93}BIOS        {#90}│",
+            "format": "{$3}{version}"
+        },
+        {
+            "type": "packages",
+            "key": "{#90}│ {#93}Packages    {#90}│",
+            "format": "{$3}{all}"
+        },
+        {
+            "type": "uptime",
+            "key": "{#90}│ {#93}Uptime      {#90}│",
+            "format": "{$3}{days} Days {hours} Hours {minutes} Mins {seconds} Secs"
+        },
+        {
+            "type": "cpu",
+            "key": "{#90}│ {#91}CPU         {#90}│",
+            "temp": true,
+            "format": "{$3}{name}"
+        },
+        {
+            "type": "memory",
+            "key": "{#90}│ {#91}Memory      {#90}│",
+            "format": "{$3}{used}/{total} ({percentage})"
+        },
+        {
+            "type": "swap",
+            "key": "{#90}│ {#91}Swap        {#90}│",
+            "format": "{$3}{used}/{total} ({percentage})"
+        },
+        {
+            "type": "disk",
+            "key": "{#90}│ {#91}Disk        {#90}│",
+            "format": "{$3}{size-used}/{size-total} ({size-percentage}) {#2}[{filesystem}]"
+        },
+        {
+            "type": "terminal",
+            "key": "{#90}│ {#95}Terminal    {#90}│",
+            "format": "{$3}{pretty-name}"
+        },
+        {
+            "type": "shell",
+            "key": "{#90}│ {#95}Shell       {#90}│",
+            "format": "{$3}{pretty-name}"
+        },
+        {
+            "type": "localip",
+            "key": "{#90}│ {#94}Local IPv4  {#90}│",
+            "showPrefixLen": true,
+            "showIpv4": true,
+            "showIpv6": false,
+            "format": "{$3}{ipv4} {#2}[{ifname}]"
+        },
+        {
+            "type": "custom",
+            "key": "{#90}╰─────────────╯",
+            "format": "{#90}╰───────────────────────────────────╯"
+        }
+    ]
+}

--- a/scripts/helpers/essentials/shell.sh
+++ b/scripts/helpers/essentials/shell.sh
@@ -26,6 +26,8 @@ FISH_FUNCTIONS="$HOME/.config/fish/functions"
 FISH_FUNCTIONS_TO_PASS="$SHELL_SCRIPT_DIRECTORY/../../configurations/essentials/shell/functions"
 FISH_CONSTANTS="$HOME/.config/fish/constants"
 FISH_CONSTANTS_TO_PASS="$SHELL_SCRIPT_DIRECTORY/../../configurations/essentials/shell/constants"
+STARSHIP_CONFIGURATION="$HOME/.config/starship.toml"
+STARSHIP_CONFIGURATION_TO_PASS="$SHELL_SCRIPT_DIRECTORY/../../configurations/essentials/shell/starship.toml"
 
 # Install shell package.
 install_packages "$FISH_SHELL" "$AUR_PACKAGE_MANAGER" "Installing shell..."
@@ -51,6 +53,14 @@ configure_fish_shell_files "$FISH_CONFIGURATION" "$FISH_CONSTANTS_TO_PASS" "$FIS
 
 # Configure shell functions.
 configure_fish_shell_files "$FISH_CONFIGURATION" "$FISH_FUNCTIONS_TO_PASS" "$FISH_FUNCTIONS" "functions"
+
+# Configure starship prompt.
+are_starship_configuration_files_the_same=$(compare_files "$STARSHIP_CONFIGURATION" "$STARSHIP_CONFIGURATION_TO_PASS")
+if [ "$are_starship_configuration_files_the_same" = "false" ]; then
+    log_info "Configuring starship prompt..."
+    mkdir -p "$HOME/.config"
+    cp -f "$STARSHIP_CONFIGURATION_TO_PASS" "$STARSHIP_CONFIGURATION"
+fi
 
 # Set default shell.
 current_shell=$(basename "$SHELL")

--- a/scripts/helpers/essentials/terminal.sh
+++ b/scripts/helpers/essentials/terminal.sh
@@ -11,9 +11,15 @@ TERMINAL_SCRIPT_DIRECTORY=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # Import functions.
 source "$TERMINAL_SCRIPT_DIRECTORY/../functions/packages.sh"
+source "$TERMINAL_SCRIPT_DIRECTORY/../functions/filesystem.sh"
 
 # Constant variable for the file path containing the terminal tools to install.
 TERMINAL_TOOLS="$TERMINAL_SCRIPT_DIRECTORY/../../packages/essentials/terminal.txt"
+
+# Constant variables for configuring fastfetch.
+FASTFETCH_CONFIGURATION_DIRECTORY="$HOME/.config/fastfetch"
+FASTFETCH_CONFIGURATION="$HOME/.config/fastfetch/config.jsonc"
+FASTFETCH_CONFIGURATION_TO_PASS="$TERMINAL_SCRIPT_DIRECTORY/../../configurations/essentials/terminal/fastfetch/config.jsonc"
 
 # Check if at least one terminal tool is not installed.
 are_terminal_packages_installed=$(are_packages_installed "$TERMINAL_TOOLS" "$AUR_PACKAGE_MANAGER")
@@ -22,4 +28,12 @@ if [ "$are_terminal_packages_installed" = "false" ]; then
 
     # Install terminal tools.
     install_packages "$TERMINAL_TOOLS" "$AUR_PACKAGE_MANAGER"
+fi
+
+# Configure fastfetch.
+are_fastfetch_configuration_files_the_same=$(compare_files "$FASTFETCH_CONFIGURATION" "$FASTFETCH_CONFIGURATION_TO_PASS")
+if [ "$are_fastfetch_configuration_files_the_same" = "false" ]; then
+    log_info "Configuring fastfetch..."
+    mkdir -p "$FASTFETCH_CONFIGURATION_DIRECTORY"
+    cp -f "$FASTFETCH_CONFIGURATION_TO_PASS" "$FASTFETCH_CONFIGURATION"
 fi

--- a/scripts/packages/essentials/terminal.txt
+++ b/scripts/packages/essentials/terminal.txt
@@ -10,3 +10,4 @@ sd
 xh
 atuin
 fdupes
+starship

--- a/scripts/packages/essentials/terminal.txt
+++ b/scripts/packages/essentials/terminal.txt
@@ -11,3 +11,7 @@ xh
 atuin
 fdupes
 starship
+fastfetch
+eza
+calc
+aria2


### PR DESCRIPTION
**What**:

1. Restores the starship prompt (dropped in a prior server-only trim), adding the package, an init line, a generic `starship.toml` (SSH-only hostname segment), and the deploy step in `shell.sh`.
2. Adds `fastfetch`, `eza`, `calc`, and `aria2` packages with matching abbreviations (`ff`, `ls`, `eva`, `dl`), plus `sm` (`btm`) and a `docker` abbreviation block (`d`, `dc`, `dcu`, `dcd`, `de`, `dcl`).
3. Adds a `fastfetch` config trimmed for a headless server: drops macOS-only fields (`Machine` row via `system_profiler`, `showPeCoreCount`) and desktop-only rows (`GPU`, `DE`, `WM`, `Font`, `Icons`, `PublicIP`), deployed via `terminal.sh`.

**Why**:

Ported over the still-useful, server-appropriate pieces of fish shell tooling that existed in this repo's history and in `macsify`, after excluding anything interactive/desktop-only (git fzf functions, agentic session pickers, `trash-cli`/`xcp`).